### PR TITLE
docs(api): change doc strings and rst files to be more consistent

### DIFF
--- a/cobra/mit/access.py
+++ b/cobra/mit/access.py
@@ -17,34 +17,32 @@ from cobra.internal.rest.accessimpl import RestAccess
 
 
 class MoDirectory(object):
+    """Creates a connection to the APIC and the MIT.
 
-    """
-    The MoDirectory class creates a connection to the APIC and the MIT.
-    MoDirectory requires an existing session and endpoint.
+    MoDirectory requires an existing session.
+
     """
 
     def __init__(self, session):
-        """
-        Arguments:
-            session: Specifies a session
+        """Initialize a MoDirectory instance
+
+        Args:
+          session (cobra.mit.session.AbstractSession): The session
+
         """
         self._accessImpl = RestAccess(session)
 
     def login(self):
-        """
-        Creates a session to an APIC.
-        """
+        """Creates a session to an APIC."""
         self._accessImpl.login()
 
     def logout(self):
-        """
-        Ends a session to an APIC.
-        """
+        """Ends a session to an APIC."""
         self._accessImpl.logout()
 
     def reauth(self):
-        """
-        Re-authenticate this session with the current authentication cookie.
+        """Re-authenticate the session with the current authentication cookie.
+
         This method can be used to extend the validity of a successful login
         credentials. This method may fail if the current session expired on
         the server side. If this method fails, the user must login again to
@@ -53,32 +51,75 @@ class MoDirectory(object):
         self._accessImpl.refreshSession()
 
     def query(self, queryObject):
-        """
-        Queries the MIT for a specified object. The queryObject provides a
-        variety of search options.
+        """Queries the Model Information Tree.
+
+        The various types of potential queryObjects provide a variety of
+        search options
+
+        Args:
+          queryObject (cobra.mit.request.AbstractRequest): A query object
+
+        Returns:
+          list: A list of Managed Objects (MOs) returned from the query
         """
         return self._accessImpl.get(queryObject)
 
     def commit(self, configObject):
-        """
-        Short-form commit operation for a configRequest
+        """Commit operation for a request object.
+
+        Commit a change on the APIC or fabric node.
+
+        Args:
+          configObject (cobra.mit.request.AbstractRequest): The configuration
+            request to commit
+
+        Returns:
+          requests.response:  The response.
+          
+            .. note::
+               This is different behavior than the query method.
+
+        Raises:
+          CommitError: If no MOs have been added to the config request
         """
         if configObject.getRootMo() is None:
             raise CommitError(0, "No mos in config request")
         return self._accessImpl.post(configObject)
 
     def lookupByDn(self, dnStrOrDn):
-        """
-        A short-form managed object (MO) query using the distinguished name(Dn)
+        """Query the APIC or fabric node by distinguished name (Dn)
+        
+        A short-form managed object (MO) query using the Dn of the MO
         of the MO.
+
+        Args:
+          dnStrOrDn (str or cobra.mit.naming.Dn): A distinguished name as a
+            :class:`cobra.mit.naming.Dn` or string
+
+        Returns:
+          None or cobra.mit.mo.Mo: None if no MO was returned otherwise
+            :class:`cobra.mit.mo.Mo`
         """
         dnQuery = DnQuery(dnStrOrDn)
         mos = self.query(dnQuery)
         return mos[0] if mos else None
 
     def lookupByClass(self, classNames, parentDn=None, propFilter=None):
-        """
+        """Lookup MO's by class
+
         A short-form managed object (MO) query by class.
+
+        Args:
+          classNames (str or list): The class name list of class names.
+            If parentDn is set, the classNames are used as a filter in a
+            subtree query for the parentDn
+          parentDn (cobra.mit.naming.Dn or str): The distinguished
+            name of the parent object as a :class:`cobra.mit.naming.Dn` or
+            string.
+          propFilter (str): A property filter expression
+
+        Returns:
+          list: A list of the managed objects found in the query.
         """
         if parentDn:
             dnQuery = DnQuery(parentDn)

--- a/cobra/mit/mo.py
+++ b/cobra/mit/mo.py
@@ -16,14 +16,63 @@ from cobra.internal.base.moimpl import BaseMo
 
 
 class Mo(BaseMo):
-    """
-    A class to create managed objects (MOs), which represent a physical or 
-    logical entity with a set of configurations and properties.
+    """Represents managed objects (MOs)
+
+    Managed objects (MOs) represent a physical or logical entity with a set of
+    configurations and properties.
+
+    Attributes:
+      dn (cobra.mit.naming.Dn): The distinguished name (Dn) of the managed
+        object (MO) - readonly
+
+      rn (cobra.mit.naming.Rn): The relative name (Rn) of the managed object
+        (MO) - readonly
+
+      status (cobra.internal.base.moimpl.MoStatus): The status of the MO -
+        readonly
+
+      parentDn (cobra.mit.naming.Dn): The parent managed object (MO)
+        distinguished name (Dn) - readonly
+
+      parent (cobra.mit.mo.Mo): The parent managed object (MO) - readonly
+
+      dirtyProps (set): modified properties that have not been committed -
+        readonly
+
+      children (cobra.internal.base.moimpl.BaseMo._ChildContainer): A container
+        for the children of this managed object - readonly
+
+      numChildren (int): The number of direct decendents for this managed
+        object - readonly
+
+      contextRoot (None or cobra.mit.mo.Mo): The managed object that is the
+        context root for this managed object
     """
     def __init__(self, parentMoOrDn, markDirty, *namingVals, **creationProps):
+        """Initialize a managed object (MO)
+        
+        This should not be called directly.  Instead initialize the Mo from
+        the model that you need.
+        
+        Args:
+          parentMoOrDn (str or cobra.mit.naming.Dn or cobra.mit.mo.Mo): The
+            parent managed object (MO) or distinguished name (Dn).
+          markDirty (bool): If True, the MO is marked has having changes that
+            need to be committed.  If False the Mo is not marked as having
+            changes that need to be committed.
+          *namingVals: Required values that are used to name the Mo, i.e. they
+            become part of the MOs distinguished name.
+          **creationProps: Properties to be set at the time the MO is created,
+            these properties can also be set after the property is created if
+            needed.
+        
+        Raises:
+          NotImplementedError: If this class is called directly
+        """
         if self.__class__ == Mo:
             raise NotImplementedError('Mo cannot be instantiated.')
-        BaseMo.__init__(self, parentMoOrDn, markDirty, *namingVals, **creationProps)
+        BaseMo.__init__(self, parentMoOrDn, markDirty, *namingVals,
+                        **creationProps)
 
     def delete(self):
         """
@@ -33,59 +82,35 @@ class Mo(BaseMo):
         BaseMo._delete(self)
 
     @property
-    def dn(self):
-        """
-        Returns the distinguished name (Dn) of the managed object (MO).
-        """    
+    def dn(self): 
         return BaseMo._dn(self)
 
     @property
     def rn(self):
-        """
-        Returns the relative name (Rn) of the managed object (MO).
-        """    
         return BaseMo._rn(self)
 
     @property
     def status(self):
-        """
-        Returns the managed object (MO) status.
-        """    
         return BaseMo._status(self)
 
     @property
     def parentDn(self):
-        """
-         Returns the distinguished name (Dn) of the parent managed object (MO).
-        """    
         return BaseMo._parentDn(self)
 
     @property
     def parent(self):
-        """
-        Returns the parent managed object (MO).
-        """    
         return BaseMo._parent(self)
 
     @property
     def dirtyProps(self):
-        """
-        Returns modified properties that have not been committed.
-        """    
         return BaseMo._dirtyProps(self)
 
     @property
     def children(self):
-        """
-        Returns the names of child managed objects (MOs).
-        """    
         return BaseMo._children(self)
 
     @property
     def numChildren(self):
-        """
-        Returns the number of child managed objects (MOs).
-        """    
         return BaseMo._numChildren(self)
 
     @property
@@ -93,26 +118,27 @@ class Mo(BaseMo):
         return self.dn.contextRoot
 
     def isPropDirty(self, propName):
-        """
-        Returns a value indicating whether a given property has a new value that has not been committed.
+        """Check if a property has been modified on this managed object
+        
+        Args:
+          propName (str): The property name as a string
+
+        Returns:
+          bool: True if the property has been modified and not commited, False
+            otherwise
         """    
         return BaseMo._isPropDirty(self, propName)
 
     def resetProps(self):
-        """
-        Resets managed object (MO) properties, discarding uncommitted changes.
+        """Resets managed object (MO) properties
+        
+        This will discard uncommitted changes.
         """    
         BaseMo._resetProps(self)
 
     def __getattr__(self, propName):
-        """
-        Returns a managed object (MO) attribute.
-        """    
         return BaseMo.__getattr__(self, propName)
 
     def __setattr__(self, propName, propValue):
-        """
-        Sets a managed object (MO) attribute.
-        """    
         BaseMo.__setattr__(self, propName, propValue)
 

--- a/cobra/services.py
+++ b/cobra/services.py
@@ -13,43 +13,38 @@
 # limitations under the License.
 
 
-"""
-This module provides an interface to uploading L4-7 device packages to the 
-controller. Refer to the "Developing L4-L7 Device Packages" document for more
-information on creating device packages
-
-Example::
-
-    moDir = cobra.mit.access.MoDirectory(
-        cobra.mit.session.LoginSession('https://apic', 'admin', 'password'))
-    moDir.login()
-
-    packageUpload = cobra.services.UploadPackage('asa-device-pkg.zip')
-    r = moDir.commit(packageUpload)
-
-"""
-
 from cobra.mit.request import AbstractRequest
 import zipfile
 
 
 class UploadPackage(AbstractRequest):
 
-    """
-    Class for uploading L4-L7 device packages to APIC
+    """Upload L4-L7 device packages to APIC
+    
+    Parameters:
+      data (str): A string containing the payload for this request in JSON
+        format - readonly
+      devicePackagePath (str): Path to the device package on the local
+        file system. No Path verification is performed, so any errors
+        accessing the specified file will be raised directly to the calling
+        function.
+        
+        .. note::
+           If validation is requested, the device package contents are verified
+           to contain a device specification XML/JSON document
     """
 
     def __init__(self, devicePackagePath, validate=False):
-        """
-        Create an UploadPackage object that can be passed to MoDirectory.commit
+        """Upload a device package to an APIC.
+        
+        :func:`cobra.mit.access.MoDirectory.commit` is required to commit the
+        upload.
 
-        :param devicePackagePath: Path to the device package on the local file
-            system
-        :type devicePackagePath: str
-
-        :param validate: If true, the device package will be validated locally
-            before attempting to upload
-        :type validate: bool
+        Args:
+          devicePackagePath (str): Path to the device package on the local
+            file system
+          validate (bool): If true, the device package will be validated
+            locally before attempting to upload
 
         """
         super(UploadPackage, self).__init__()
@@ -58,14 +53,14 @@ class UploadPackage(AbstractRequest):
         self.uriBase = "/ppi/node/mo"
 
     def requestargs(self, session):
-        """
-        Returns the POST arguments for this request
+        """Get the request arguments for this object.
 
-        :param session: session object for which the request will be sent
-        :type session: cobra.mit.session.AbstractSession
+        Args:
+          session (cobra.mit.session.AbstractSession): The session to be used
+            to build the the requestarguments
 
-        :returns: requests style kwargs that can be passed to request.post()
-        :rtype: dict
+        Returns:
+          dict: A dictionary containing the arguments
         """
         uriPathandOptions = self.getUriPathAndOptions(session)
         headers = session.getHeaders(uriPathandOptions, self.data)
@@ -80,48 +75,26 @@ class UploadPackage(AbstractRequest):
 
     @property
     def data(self):
-        """
-        Returns the data this request should post
-
-        :returns: string containing contents of device package
-        :rtype: str
-        """
         return open(self.__devicePackagePath, 'rb').read()
 
     def getUrl(self, session):
-        """
-        Returns the URI this request will access
+        """Get the URL for this request, includes all options as well.
+        
+        Args:
+          session (cobra.mit.session.AbstractSession): The session to use for
+            this query.
 
-        :param session: session object for which the request will be sent
-        :type session: cobra.mit.session.AbstractSession
+        Returns:
+          str: A string containing the request url
         """
         return session.url + self.getUriPathAndOptions(session)
 
-    # property setters / getters for this class
-
     @property
     def devicePackagePath(self):
-        """
-        Returns the currently configured path to the device package
-
-        :returns: Path to the device package on the local file system
-        :rtype: str
-        """
         return self.__devicePackagePath
 
     @devicePackagePath.setter
     def devicePackagePath(self, devicePackagePath):
-        """
-        Sets the device package path for this request and if validation is
-        requested, will ensure that the device package contains the
-        device specification XML/JSON document
-
-        :param devicePackagePath: Path to the device package on the local
-            file system. No path verification is performed, so any errors
-            accessing the specified file will be raised directly to the calling
-            function.
-        :type devicePackagePath: str
-        """
         if self.__validate:
             # Device package spec will look at the first .xml document and use
             # that as the device specification, so it must contain at least
@@ -133,7 +106,7 @@ class UploadPackage(AbstractRequest):
                         break
                 else:
                     raise AttributeError('Device package {0} missing required '
-                                         'device specification document'.format(
-                                             devicePackagePath))
+                                         'device specification '
+                                         'document'.format(devicePackagePath))
 
         self.__devicePackagePath = devicePackagePath

--- a/docs/source/api-ref/access.rst
+++ b/docs/source/api-ref/access.rst
@@ -19,4 +19,4 @@ MoDirectory requires an existing session and endpoint.
 .. autoclass:: cobra.mit.access.MoDirectory
    :members:
    :special-members:
-
+   :exclude-members: __weakref__

--- a/docs/source/api-ref/meta.rst
+++ b/docs/source/api-ref/meta.rst
@@ -12,6 +12,7 @@ Class that represents an object category.
 .. autoclass:: cobra.mit.meta.Category
    :members:
    :special-members:
+   :exclude-members: __weakref__
 
 ClassLoader
 ------------------
@@ -20,6 +21,7 @@ Class that loads a specified class.
 .. autoclass:: cobra.mit.meta.ClassLoader
    :members:
    :special-members:
+   :exclude-members: __weakref__
 
 ClassMeta
 ------------------
@@ -28,6 +30,7 @@ Class that provides information about an object class.
 .. autoclass:: cobra.mit.meta.ClassMeta
    :members:
    :special-members:
+   :exclude-members: __weakref__
 
 Constant
 ------------------
@@ -35,7 +38,8 @@ Constant
 .. autoclass:: cobra.mit.meta.Constant
    :members:
    :special-members:
-   
+   :exclude-members: __weakref__
+
 NamedSourceRelationMeta
 -------------------------
 
@@ -49,13 +53,14 @@ PropMeta
 .. autoclass:: cobra.mit.meta.PropMeta
    :members:
    :special-members:
+   :exclude-members: __weakref__
 
 SourceRelationMeta
 ------------------
 
 .. autoclass:: cobra.mit.meta.SourceRelationMeta
    :members:
-   :special-members:   
+   :special-members:
 
 TargetRelationMeta
 ------------------

--- a/docs/source/api-ref/mo.rst
+++ b/docs/source/api-ref/mo.rst
@@ -2,61 +2,14 @@ Managed Object (MO) Module
 ===========================
 .. module:: mo
 
-A Managed Object (MO) is an abstract representation of a physical or logical entity that contain a set of configurations and properties, such as a server, processor, or resource pool. The MO module represents MOs.
+A Managed Object (MO) is an abstract representation of a physical or logical
+entity that contain a set of configurations and properties, such as a server,
+processor, or resource pool. The MO module represents MOs.
 
-The APIC system configuration and state are modeled as a collection of managed objects (MOs). For example, servers, chassis, I/O cards, and processors are physical entities represented as MOs; resource pools, user roles, service profiles, and policies are logical entities represented as MOs.
-
-The following sections describe the classes in the MO module.
-
-.. autoclass:: cobra.mit.mo.Mo
-   :members:
-   :special-members:
-
-
-Adding a Tenant
-------------------
-A tenant is a policy owner in the virtual fabric. A tenant can be either a private or a shared entity. For example,
-you can create a securely partitioned private tenant or a tenant with contexts and bridge domains that are shared by
-other tenants. Common names for shared tenants are common, default, or infra.
-
-In the management information model, a tenant is represented by a managed object (MO) of class fv:Tenant.
-According to the *Cisco APIC Management Information Model Reference*, an object of the fv:Tenant class is
-a child of the policy resolution universe (uni) class and has a distinguished name (DN) format of uni/tn-[name].
-
-To create a new tenant, specify the class and naming information, either in the message body or in the URI.
-To create a new tenant named ExampleCorp using the Python API, use the Tenant() method as follows::
-
-    # Import the config request
-    from cobra.mit.request import ConfigRequest
-    configReq = ConfigRequest()
-
-    # Import the tenant class from the model
-    from cobra.model.fv import Tenant
-
-    # Get the top level policy universe directory
-    uniMo = moDir.lookupByDn('uni')
-
-    # create the tenant object
-    fvTenantMo = Tenant(uniMo, 'ExampleCorp')
-
-Adding a User
-------------------
-An APIC user account contains, in addition to a name and password, information about the user's privilege level (role) and the scope (domain) of the user's control in the fabric. A cloud administrator, for example, might
-have global control, including the ability to create tenants and to assign additional administrators, while a
-tenant administrator is typically restricted to the tenant's domain or network. When you configure a user
-account, you can specify additional configuration items, such as a password expiration policy, or you can
-omit those items to accept the default settings.
-In the management information model, an APIC user is represented by a managed object (MO) of class
-aaa:User. According to the *Cisco APIC Management Information Model Reference*, an object of the aaa:User
-class has a distinguished name (DN) format of uni/userext/user-[name]. The direct properties (attributes)
-of the aaa:User class do not include fields for the user domain or privilege level, but the reference for this
-class indicates a child class (subtree) of aaa:UserDomain, which has a child class of aaa:UserRole.
-
-The API command structure that you would use to add the new user can include the configuration of the user domain and privilege level
-in these child classes in the following hierarchy:
-
-* aaa:User - The user object can contain one or more user domain child objects.
-* aaa:UserDomain - The user domain object can contain one or more user role objects.
+The APIC system configuration and state are modeled as a collection of managed
+objects (MOs). For example, servers, chassis, I/O cards, and processors are
+physical entities represented as MOs; resource pools, user roles, service
+profiles, and policies are logical entities represented as MOs.
 
 Accessing Properties
 ---------------------
@@ -84,4 +37,9 @@ The managed object (MO) object properties enable you to access related objects i
 Verifying Object Status
 -------------------------
 You can use the status property to access the status of the Mo.
+
+.. autoclass:: cobra.mit.mo.Mo
+   :members:
+   :special-members:
+
 

--- a/docs/source/api-ref/naming.rst
+++ b/docs/source/api-ref/naming.rst
@@ -2,57 +2,78 @@ Naming Module
 =================
 .. module:: naming
 
-The APIC system configuration and state are modeled as a collection of managed objects (MOs), which are
-abstract representations of a physical or logical entity that contain a set of configurations and properties. For
-example, servers, chassis, I/O cards, and processors are physical entities that are represented as MOs; resource pools,
-user roles, service profiles, and policies are logical entities represented as MOs.
+The APIC system configuration and state are modeled as a collection of managed
+objects (MOs), which are abstract representations of a physical or logical
+entity that contain a set of configurations and properties. For example,
+servers, chassis, I/O cards, and processors are physical entities that are
+represented as MOs; resource pools, user roles, service profiles, and policies
+are logical entities represented as MOs.
 
-At runtime, all MOs are organized in a tree structure, which is called the Management Information Tree (MIT). This tree provides structured and consistent access to all MOs in the system. Each MO is identified by its relative name (RN) and 
-distinguished name (DN).  You can manage MO naming by using the naming module of the Python API.
+At runtime, all MOs are organized in a tree structure, which is called the
+Management Information Tree (MIT). This tree provides structured and consistent
+access to all MOs in the system. Each MO is identified by its relative name
+(RN) and distinguished name (DN).  You can manage MO naming by using the naming
+module of the Python API.
 
-You can use the naming module to create and parse object names, as well as access a variety of information about the object, including the relative name, parent or ancestor name, naming values, meta class, or MO class.  You can also perform operations on an MO such as appending an Rn to a Dn or cloning an MO.
+You can use the naming module to create and parse object names, as well as
+access a variety of information about the object, including the relative name,
+parent or ancestor name, naming values, meta class, or MO class.  You can also
+perform operations on an MO such as appending an Rn to a Dn or cloning an MO.
 
 Relative Name (RN)
 ------------------
 
-A relative name (RN) identifies an object from its siblings within the context of the parent MO. An Rn is a list of prefixes and properties that
-uniquely identify the object from its siblings.
+A relative name (RN) identifies an object from its siblings within the context
+of the parent MO. An Rn is a list of prefixes and properties that uniquely
+identify the object from its siblings.
 
-For example, the Rn for an MO of type aaaUser is user-john.  user- is the naming prefix and john is the *name* value.
+For example, the Rn for an MO of type aaaUser is user-john.  user- is the
+naming prefix and john is the *name* value.
 
-You can use an RN class to convert between an MO's RN and constituent naming values.
+You can use an RN class to convert between an MO's RN and constituent naming
+values.
+
 The string form of an RN is {prefix}{val1}{prefix2}{Val2} (...)
-**Note:** The naming value is enclosed in brackets ([]) if the meta object specifies that properties be delimited.
+
+.. note::
+   The naming value is enclosed in brackets ([]) if the meta object specifies
+   that properties be delimited.
 
 
 .. autoclass:: cobra.mit.naming.Rn
    :members:
    :special-members:
+   :exclude-members: __weakref__,__cmp__,__hash__,__str__
 
 Distinguished Name (DN)
 -----------------------
 
-A distinguished name (DN) uniquely identifies a managed object (MO). A DN is an ordered list of relative names, such as the following:
+A distinguished name (DN) uniquely identifies a managed object (MO). A DN is an
+ordered list of relative names, such as the following:
 
 	dn = rn1/rn2/rn3/....
 
-In the next example, the DN provides a fully qualified path for user-john from the top of the MIT to the MO.
+In the next example, the DN provides a fully qualified path for user-john from
+the top of the MIT to the MO.
 
 	dn = "uni/userext/user-john"
 
 	This DN consists of these relative names:
 
 =================  =============   =======================
-  Relative Name        Class             Description       
+  Relative Name        Class             Description
 =================  =============   =======================
   uni               polUni            Policy universe
   userext           aaaUserEp         User endpoint
   user-john         aaaUser           Local user account
 =================  =============   =======================
 
-Note: When using the API to filter by distinguished name (DN), we recommend that you use the full DN rather than a partial DN.
+.. note::
+   When using the API to filter by distinguished name (DN), we recommend that
+   you use the full DN rather than a partial DN.
 
 
 .. autoclass:: cobra.mit.naming.Dn
    :members:
    :special-members:
+   :exclude-members: __weakref__,__cmp__,__hash__,__str__,__len__

--- a/docs/source/api-ref/request.rst
+++ b/docs/source/api-ref/request.rst
@@ -2,7 +2,7 @@ Request Module
 ==============
 .. module:: request
 
-The request module handles configuration and queries to the APIC.  
+The request module handles configuration and queries to the APIC.
 
 You can use the request module to:
 
@@ -10,48 +10,6 @@ You can use the request module to:
 * Call a method within an MO
 * Delete an MO
 * Run a query to read the properties and status of an MO or discover objects
-
-The following sections describe the classes in the request module.
-
-AbstractQuery
--------------
-
-Class that represents an abstract query. ClassQuery and DnQuery use this class.
-
-.. autoclass:: cobra.mit.request.AbstractQuery
-   :members:
-   :special-members:
-
-DnQuery
--------
-
-Class that creates a query object based on distinguished name (DN).
-
-.. autoclass:: cobra.mit.request.DnQuery
-   :members:
-   :special-members:
-
-ClassQuery
-----------
-
-Class that creates a query based on object class.
-
-.. autoclass:: cobra.mit.request.ClassQuery
-   :members:
-   :special-members:
-
-ConfigRequest
--------------
-
-Class that handles configuration requests. The commit function uses this class.
-
-    # Import the config request
-    from cobra.mit.request import ConfigRequest
-    configReq = ConfigRequest()
-
-.. autoclass:: cobra.mit.request.ConfigRequest
-   :members:
-   :special-members:	
 
 Using Queries
 -------------
@@ -108,6 +66,59 @@ module.  The ConfigRequest class enables you to:
 * Remove an MO
 * Verify if an MO is present in an uncommitted configuration
 * Return the root MO for a given object
+
+AbstractRequest
+---------------
+
+Class that represents an abstract request.  AbstractQuery and ConfigRequest
+derive from this class.
+
+.. autoclass:: cobra.mit.request.AbstractRequest
+   :members:
+   :special-members:
+   :exclude-members: __weakref__
+
+AbstractQuery
+-------------
+
+Class that represents an abstract query. ClassQuery and DnQuery derive from
+this class.
+
+.. autoclass:: cobra.mit.request.AbstractQuery
+   :members:
+   :special-members:
+
+DnQuery
+-------
+
+Class that creates a query object based on distinguished name (DN).
+
+.. autoclass:: cobra.mit.request.DnQuery
+   :members:
+   :special-members:
+
+ClassQuery
+----------
+
+Class that creates a query object based on object class.
+
+.. autoclass:: cobra.mit.request.ClassQuery
+   :members:
+   :special-members:
+
+ConfigRequest
+-------------
+
+Class that handles configuration requests. The
+:func:`cobra.mit.access.MoDirectory.commit` function uses this class.::
+
+    # Import the config request
+    from cobra.mit.request import ConfigRequest
+    configReq = ConfigRequest()
+
+.. autoclass:: cobra.mit.request.ConfigRequest
+   :members:
+   :special-members:
 
 Tag Request
 -----------
@@ -166,3 +177,13 @@ Example Usage:
 .. autoclass:: cobra.mit.request.TagsRequest
    :members:
    :special-members:
+
+TraceQuery
+----------
+
+A class that creates a trace query
+
+.. autoclass:: cobra.mit.request.TraceQuery
+   :members:
+   :special-members:
+

--- a/docs/source/api-ref/services.rst
+++ b/docs/source/api-ref/services.rst
@@ -2,8 +2,19 @@ Services Module
 ===============
 .. module:: services
 
-The services module provides you with the means to upload a L4-L7 device
-package.
+This module provides an interface to uploading L4-7 device packages to the
+controller. Refer to the **Developing L4-L7 Device Packages** document for more
+information on creating device packages.
+
+Example::
+
+    session = cobra.mit.session.LoginSession('https://apic', 'admin',
+                                             'password', secure=False)
+    moDir = cobra.mit.access.MoDirectory(session)
+    moDir.login()
+
+    packageUpload = cobra.services.UploadPackage('asa-device-pkg.zip')
+    response = moDir.commit(packageUpload)
 
 The following sections describe the classes in the services module.
 
@@ -12,6 +23,6 @@ UploadPackage
 Class for uploading L4-L7 device packages to APIC
 
 .. autoclass:: cobra.services.UploadPackage
-    :members:
-    :special-members:
-
+   :members:
+   :special-members:
+   :exclude-members: __weakref__

--- a/docs/source/api-ref/session.rst
+++ b/docs/source/api-ref/session.rst
@@ -21,8 +21,9 @@ AbstractSession
 Class that abstracts sessions
 
 .. autoclass:: cobra.mit.session.AbstractSession
-    :members:
-    :special-members:
+   :members:
+   :special-members:
+   :exclude-members: __weakref__
 
 LoginSession
 ------------
@@ -43,5 +44,5 @@ fallback to openssl using subprocess and temporary files that should work for
 most platforms.
 
 .. autoclass:: cobra.mit.session.CertSession
-    :members:
-    :special-members:
+   :members:
+   :special-members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,6 +53,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
+    'sphinxcontrib.napoleon'
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,19 @@ class PyTest(TestCommand):
         errno = pytest.main(self.test_args)
         sys.exit(errno)
 
+install_requires = ['requests']
+
+# Doc build instructions:
+# Clone the repo
+# cd into the main repo directory
+# install with the [docs] extra as an editable install:  pip install -e .[docs]
+# cd into the docs directory
+# do a make html
+# Built docs are in docs/build/html
+docs_requires = install_requires + ['sphinx<1.3', 'sphinxcontrib-napoleon']
+
+tests_requires = install_requires + ['pytest', 'responses']
+
 setup(
     name='acicobra',
     version='0.1',
@@ -60,13 +73,11 @@ setup(
     ],
     keywords='data center networking configuration management',
     license='http://www.apache.org/licenses/LICENSE-2.0',
-    install_requires=[
-        'setuptools',
-        'requests',
-    ],
+    install_requires=install_requires,
     extras_require={
         'ssl': ['pyOpenSSL',],
+        'docs': docs_requires,
     },
-    tests_require = ['pytest', 'responses'],
+    tests_require=tests_requires,
     cmdclass = {'test': PyTest},
 )


### PR DESCRIPTION
Change the doc strings and rst files for the api refrence to be
more consistent and follow the napoleon google style.  Also add
a means to install the doc requirements through a new [docs]
extra.  Docs now need the sphinxcontrib-napoleon package to be
processed properly.

Closes #3
