### PR TITLE
feat(python2and3): update cobra to support both python versions 2 and 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: python
 python:
   - "2.7"
+  - "3.4"
 # command to install dependencies
 install: 
   - "pip install requests"
   - "pip install pyOpenSSL"
   - "pip install responses"
-  - "python setup.py -q install"
+  - "pip install future"
   - "pip install sphinxcontrib-napoleon"
+  - "python setup.py -q install"
 
 script:
   - python -m pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install:
   - "python setup.py -q install"
 
 script:
-  - python -m pytest
+  - python -m pytest -vv

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ install:
   - "pip install pyOpenSSL"
   - "pip install responses"
   - "pip install future"
-  - "pip install sphinxcontrib-napoleon"
   - "python setup.py -q install"
+  - "pip install sphinxcontrib-napoleon"
 
 script:
   - python -m pytest -vv

--- a/cobra/internal/base/moimpl.py
+++ b/cobra/internal/base/moimpl.py
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import unicode_literals
+from builtins import next
+from builtins import str
+from builtins import object
+
 from cobra.mit.naming import Dn
 from cobra.mit.naming import Rn
 
@@ -108,7 +113,7 @@ class BaseMo(object):
                 return len(self._childObjects)
 
             def __iter__(self):
-                return iter(self._childObjects.values())
+                return iter(list(self._childObjects.values()))
 
             def _checkKey(self, key, mo):
                 meta = self._childClass.meta
@@ -139,10 +144,10 @@ class BaseMo(object):
 
         class _ChildIter(object):
             def __init__(self, classContainers):
-                self._containers = iter(classContainers.values())
+                self._containers = iter(list(classContainers.values()))
                 self._currentContainer = None
 
-            def next(self):
+            def __next__(self):
                 if self._currentContainer is None:
                     # If no more containers this statement will throw an
                     # StopIteration exception and we exit else we move on
@@ -204,22 +209,20 @@ class BaseMo(object):
         self.__dict__['_BaseMo__rn'] = Rn(self.__meta, *namingVals)
         self.__dict__['_BaseMo__dn'] = None
 
-        if isinstance(parentMoOrDn, str):
-            self.__dict__['_BaseMo__parentDnStr'] = parentMoOrDn
-            self.__dict__['_BaseMo__parentDn'] = None
-            self.__dict__['_BaseMo__parentMo'] = None
-        elif isinstance(parentMoOrDn, unicode):
-            self.__dict__['_BaseMo__parentDnStr'] = str(parentMoOrDn)
-            self.__dict__['_BaseMo__parentDn'] = None
-            self.__dict__['_BaseMo__parentMo'] = None
-        elif isinstance(parentMoOrDn, Dn):
+        if isinstance(parentMoOrDn, Dn):
             self.__dict__['_BaseMo__parentDn'] = parentMoOrDn.clone()
             self.__dict__['_BaseMo__parentMo'] = None
         elif isinstance(parentMoOrDn, BaseMo):
             self.__dict__['_BaseMo__parentMo'] = parentMoOrDn
             self.__dict__['_BaseMo__parentDn'] = parentMoOrDn.dn.clone()
         else:
-            raise ValueError('parent mo or dn must be specified')
+            parentMoOrDn = str(parentMoOrDn)
+            if isinstance(parentMoOrDn, str):
+                self.__dict__['_BaseMo__parentDnStr'] = parentMoOrDn
+                self.__dict__['_BaseMo__parentDn'] = None
+                self.__dict__['_BaseMo__parentMo'] = None
+            else:
+                raise ValueError('parent mo or dn must be specified')
 
         # Set the naming props
         self.__dirtyProps.add('status')
@@ -233,7 +236,7 @@ class BaseMo(object):
 
         # Set the creation props
         props = self.__meta.props
-        for name, value in creationProps.items():
+        for name, value in list(creationProps.items()):
             propMeta = props[name]
             value = propMeta.makeValue(value)
             self.__dict__[name] = value

--- a/cobra/internal/base/moimpl.py
+++ b/cobra/internal/base/moimpl.py
@@ -179,8 +179,8 @@ class BaseMo(object):
                     # Accessing a child like an attribute will lead to the
                     # childPrefix being passed in without a hyphen, add it
                     # here for this circumstance
-                    if childPrefix[-1] != '-':
-                        if len(childMeta.namingProps) > 0:
+                    if (childPrefix[-1] != '-' and
+                        len(childMeta.namingProps) > 0):
                             newPrefix = childPrefix + '-'
                     if newPrefix == prefix:
                         # Do not overwrite the classContainer for a lookup

--- a/cobra/internal/base/moimpl.py
+++ b/cobra/internal/base/moimpl.py
@@ -132,7 +132,7 @@ class BaseMo(object):
                 namingValsIter = iter(namingVals)
                 for propMeta in meta.namingProps:
                     moVal = getattr(mo, propMeta.name)
-                    keyVal = namingValsIter.next()
+                    keyVal = next(namingValsIter)
                     if moVal != keyVal:
                         raise ValueError("'%s' must be '%s' for mo '%s'" %
                                          (keyVal, moVal, str(mo.rn)))
@@ -147,13 +147,13 @@ class BaseMo(object):
                     # If no more containers this statement will throw an
                     # StopIteration exception and we exit else we move on
                     # to the next container
-                    self._currentContainer = iter(self._containers.next())
+                    self._currentContainer = iter(next(self._containers))
                 try:
-                    return self._currentContainer.next()
+                    return next(self._currentContainer)
                 except StopIteration:
                     # Current container is done, see if we have anything else
                     self._currentContainer = None
-                    return self.next()
+                    return next(self)
 
             def __iter__(self):
                 return self
@@ -226,7 +226,7 @@ class BaseMo(object):
         namingValsIter = iter(namingVals)
         for namingPropMeta in self.__meta.namingProps:
             propName = namingPropMeta.name
-            value = namingValsIter.next()
+            value = next(namingValsIter)
             value = namingPropMeta.makeValue(value)
             self.__dict__[propName] = value
             self.__dirtyProps.add(propName)

--- a/cobra/internal/codec/jsoncodec.py
+++ b/cobra/internal/codec/jsoncodec.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from builtins import str
 import json
 from cobra.mit.meta import ClassLoader
 from cobra.internal.codec import parseMoClassName, getParentDn
@@ -23,7 +24,7 @@ def parseJSONError(rspText, errorClass, httpCode=None):
         data = rspDict.get('imdata', None)
         if data:
             firstRecord = data[0]
-            if 'error' == firstRecord.keys()[0]:
+            if 'error' == list(firstRecord.keys())[0]:
                 errorDict = firstRecord['error']
                 reasonStr = errorDict['attributes']['text']
                 errorCode = errorDict['attributes']['code']
@@ -45,7 +46,7 @@ def fromJSONDict(moDict):
 
     allMos = []
     for moNode in rootNode:
-        className = moNode.keys()[0]
+        className = list(moNode.keys())[0]
         moData = moNode[className]
         mo = _createMo(className, moData, None)
         allMos.append(mo)
@@ -81,7 +82,7 @@ def _createMo(moClassName, moData, parentMo):
 
     children = moData.get('children', [])
     for childNode in children:
-        className = childNode.keys()[0]
+        className = list(childNode.keys())[0]
         moData = childNode[className]
         _createMo(className, moData, mo)
 
@@ -129,6 +130,6 @@ def __toJSONDict(mo, includeAllProps=False, prettyPrint=False, excludeChildren=F
 def toJSONStr(mo, includeAllProps=False, prettyPrint=False, excludeChildren=False):
     jsonDict = __toJSONDict(mo, includeAllProps, prettyPrint, excludeChildren)
     indent = 2 if prettyPrint else None
-    jsonStr = json.dumps(jsonDict, indent=indent)
+    jsonStr = json.dumps(jsonDict, indent=indent, sort_keys=True)
 
     return jsonStr

--- a/cobra/internal/codec/xmlcodec.py
+++ b/cobra/internal/codec/xmlcodec.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from builtins import str
+
 import xml.etree.cElementTree as ET
 import xml.dom.minidom
 from cobra.mit.meta import ClassLoader
@@ -53,7 +55,7 @@ def _createMo(node, parentMo):
     pyClass = ClassLoader.loadClass(fqClassName)
     parentDnStr = None
     moProps = {}
-    for attr, val in node.attrib.items():
+    for attr, val in list(node.attrib.items()):
         if (attr != 'dn' and attr != 'rn' and attr != 'instanceId' and
                 attr != 'status'):
             moProps[attr] = str(val)

--- a/cobra/internal/rest/accessimpl.py
+++ b/cobra/internal/rest/accessimpl.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from builtins import str
+from builtins import object
+
 import requests
 from cobra.internal.codec.jsoncodec import fromJSONStr, parseJSONError
 from cobra.internal.codec.xmlcodec import fromXMLStr, parseXMLError

--- a/cobra/internal/rest/accessimpl.py
+++ b/cobra/internal/rest/accessimpl.py
@@ -40,7 +40,7 @@ class LoginRequest(AbstractRequest):
                 }
             }
         }
-        return json.dumps(userJson)
+        return json.dumps(userJson, sort_keys=True)
 
     def requestargs(self, session):
         uriPathandOptions = self.getUriPathAndOptions(session)

--- a/cobra/mit/access.py
+++ b/cobra/mit/access.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from builtins import object
+
 from cobra.mit.request import DnQuery, ClassQuery, CommitError
 from cobra.internal.rest.accessimpl import RestAccess
 

--- a/cobra/mit/access.py
+++ b/cobra/mit/access.py
@@ -82,8 +82,6 @@ class MoDirectory(object):
         Raises:
           CommitError: If no MOs have been added to the config request
         """
-        if configObject.getRootMo() is None:
-            raise CommitError(0, "No mos in config request")
         return self._accessImpl.post(configObject)
 
     def lookupByDn(self, dnStrOrDn):

--- a/cobra/mit/meta.py
+++ b/cobra/mit/meta.py
@@ -156,8 +156,8 @@ class ClassMeta(object):
         self.isExplicit = False
         self.isNamed = False
 
-        self.writeAccessMask = 0L
-        self.readAccessMask = 0L
+        self.writeAccessMask = 0
+        self.readAccessMask = 0
         self.isDomainable = False
         self.isReadOnly = False
         self.isConfigurable = False
@@ -229,7 +229,7 @@ class ClassMeta(object):
                 self._classNames = iter(container.names)
 
             def next(self):
-                nextClassName = self._classNames.next()
+                nextClassName = next(self._classNames)
                 return self._container[nextClassName]
 
             def __iter__(self):

--- a/cobra/mit/meta.py
+++ b/cobra/mit/meta.py
@@ -1,7 +1,4 @@
-from past.builtins import cmp
-from builtins import str
-from builtins import next
-from builtins import object
+
 # Copyright 2015 Cisco Systems, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +12,11 @@ from builtins import object
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from past.builtins import cmp
+from builtins import str
+from builtins import next
+from builtins import object
 
 import importlib
 

--- a/cobra/mit/meta.py
+++ b/cobra/mit/meta.py
@@ -1,3 +1,7 @@
+from past.builtins import cmp
+from builtins import str
+from builtins import next
+from builtins import object
 # Copyright 2015 Cisco Systems, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -228,7 +232,7 @@ class ClassMeta(object):
                 self._container = container
                 self._classNames = iter(container.names)
 
-            def next(self):
+            def __next__(self):
                 nextClassName = next(self._classNames)
                 return self._container[nextClassName]
 
@@ -237,7 +241,7 @@ class ClassMeta(object):
 
         @property
         def names(self):
-            return self._classes.keys()
+            return list(self._classes.keys())
 
         def add(self, className):
             self._classes[className] = None
@@ -270,7 +274,7 @@ class ClassMeta(object):
 
         @property
         def names(self):
-            return self._props.keys()
+            return list(self._props.keys())
 
         def __getitem__(self, propName):
             return self._props[propName]
@@ -282,7 +286,7 @@ class ClassMeta(object):
             return len(self._props)
 
         def __iter__(self):
-            return iter(self._props.values())
+            return iter(list(self._props.values()))
 
         def __getattr__(self, propName):
             if propName not in self._props:

--- a/cobra/mit/naming.py
+++ b/cobra/mit/naming.py
@@ -1,7 +1,3 @@
-from past.builtins import cmp
-from builtins import next
-from builtins import str
-from builtins import object
 # Copyright 2015 Cisco Systems, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,6 +11,11 @@ from builtins import object
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from past.builtins import cmp
+from builtins import next
+from builtins import str
+from builtins import object
 
 from cobra.mit.meta import ClassLoader
 from collections import deque

--- a/cobra/mit/naming.py
+++ b/cobra/mit/naming.py
@@ -1,3 +1,7 @@
+from past.builtins import cmp
+from builtins import next
+from builtins import str
+from builtins import object
 # Copyright 2015 Cisco Systems, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/cobra/mit/naming.py
+++ b/cobra/mit/naming.py
@@ -112,7 +112,7 @@ class Rn(object):
                     raise ValueError('rn "%s" must be %s' % (rn, rnFormat))
 
                 if hasProp:
-                    nPropMeta = propMetaIter.next()
+                    nPropMeta = next(propMetaIter)
                     needPropDelimiter = nPropMeta.needDelimiter
 
                 start += len(rnPrefix)
@@ -190,7 +190,7 @@ class Rn(object):
             namingProps = {}
             namingValsIter = iter(self.__namingVals)
             for propMeta in self.__meta.namingProps:
-                namingProps[propMeta.name] = namingValsIter.next()
+                namingProps[propMeta.name] = next(namingValsIter)
             return self.__meta.rnFormat % namingProps
         else:
             return self.__meta.rnFormat

--- a/cobra/mit/request.py
+++ b/cobra/mit/request.py
@@ -927,7 +927,7 @@ class ConfigRequest(AbstractRequest):
             'headers': headers,
             'verify': session.secure,
             'timeout': session.timeout,
-            'data': data
+            'data': str(data)
         }
         return kwargs
 
@@ -1004,7 +1004,7 @@ class ConfigRequest(AbstractRequest):
 
         # This dict stores all entries added to the tree. Fast lookups
         flatTreeDict = {}
-        dns = self.__configMos.keys()
+        dns = list(self.__configMos.keys())
         rootDn = Dn.findCommonParent(dns)
         configMos = dict(self.__configMos)
 

--- a/cobra/mit/request.py
+++ b/cobra/mit/request.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from builtins import str
+from builtins import object
+
 from cobra.mit.naming import Dn
 from cobra.internal.codec.jsoncodec import toJSONStr
 from cobra.internal.codec.xmlcodec import toXMLStr
@@ -49,8 +52,8 @@ class AbstractRequest(object):
         optionStr = ''
         if options:
             options = ['%s=%s' % (n, str(v)) if v else None
-                       for n, v in options.items()]
-            optionStr += '&'.join(filter(None, options))
+                       for n, v in list(options.items())]
+            optionStr += '&'.join([_f for _f in options if _f])
         return optionStr
 
     def getUriPathAndOptions(self, session):
@@ -174,8 +177,8 @@ class AbstractQuery(AbstractRequest):
 
     @property
     def options(self):
-        return '&'.join(filter(None, [AbstractRequest.makeOptions(
-            self.__options), super(AbstractQuery, self).options]))
+        return '&'.join([_f for _f in [AbstractRequest.makeOptions(
+            self.__options), super(AbstractQuery, self).options] if _f])
 
     @property
     def propInclude(self):
@@ -377,8 +380,8 @@ class DnQuery(AbstractQuery):
 
     @property
     def options(self):
-        return '&'.join(filter(None, [AbstractRequest.makeOptions(
-            self.__options), super(DnQuery, self).options]))
+        return '&'.join([_f for _f in [AbstractRequest.makeOptions(
+            self.__options), super(DnQuery, self).options] if _f])
 
     @property
     def dnStr(self):
@@ -491,8 +494,8 @@ class ClassQuery(AbstractQuery):
 
     @property
     def options(self):
-        return '&'.join(filter(None, [AbstractRequest.makeOptions(
-            self.__options), super(ClassQuery, self).options]))
+        return '&'.join([_f for _f in [AbstractRequest.makeOptions(
+            self.__options), super(ClassQuery, self).options] if _f])
 
     @property
     def className(self):
@@ -610,8 +613,8 @@ class TraceQuery(AbstractQuery):
 
     @property
     def options(self):
-        return '&'.join(filter(None, [AbstractRequest.makeOptions(
-            self.__options), super(TraceQuery, self).options]))
+        return '&'.join([_f for _f in [AbstractRequest.makeOptions(
+            self.__options), super(TraceQuery, self).options] if _f])
 
     @property
     def targetClass(self):
@@ -685,8 +688,8 @@ class TagsRequest(AbstractRequest):
 
     @property
     def options(self):
-        return '&'.join(filter(None, [AbstractRequest.makeOptions(
-            self.__options), super(TagsRequest, self).options]))
+        return '&'.join([_f for _f in [AbstractRequest.makeOptions(
+            self.__options), super(TagsRequest, self).options] if _f])
 
     @property
     def dnStr(self):
@@ -745,8 +748,7 @@ class TagsRequest(AbstractRequest):
     def _get_tags_string(value):
         if isinstance(value, list):
             value = ','.join(value)
-        elif not isinstance(value, basestring):
-            # # TODO: PYTHON 3 TIMEBOMB basestring ##
+        elif not isinstance(value, str):
             raise ValueError("add or remove should be a list or a string " +
                              "{0}".format(type(value)))
         return value
@@ -788,8 +790,8 @@ class AliasRequest(AbstractRequest):
 
     @property
     def options(self):
-        return '&'.join(filter(None, [AbstractRequest.makeOptions(
-            self.__options), super(AliasRequest, self).options]))
+        return '&'.join([_f for _f in [AbstractRequest.makeOptions(
+            self.__options), super(AliasRequest, self).options] if _f])
 
     @property
     def dnStr(self):
@@ -882,8 +884,8 @@ class ConfigRequest(AbstractRequest):
 
     @property
     def options(self):
-        return '&'.join(filter(None, [AbstractRequest.makeOptions(
-            self.__options), super(ConfigRequest, self).options]))
+        return '&'.join([_f for _f in [AbstractRequest.makeOptions(
+            self.__options), super(ConfigRequest, self).options] if _f])
 
     @property
     def data(self):
@@ -1016,7 +1018,7 @@ class ConfigRequest(AbstractRequest):
                                                       rootMo)
 
         # Add the rest of the mos to the root.
-        childMos = sorted(configMos.values(), key=lambda x: x.dn)
+        childMos = sorted(list(configMos.values()), key=lambda x: x.dn)
         for childMo in childMos:
             addDescendantMo(rootMo, childMo)
 
@@ -1163,8 +1165,8 @@ class MultiQuery(AbstractQuery):
 
     @property
     def options(self):
-        return '&'.join(filter(None, [AbstractRequest.makeOptions(
-            self.__options), super(MultiQuery, self).options]))
+        return '&'.join([_f for _f in [AbstractRequest.makeOptions(
+            self.__options), super(MultiQuery, self).options] if _f])
 
     @property
     def target(self):

--- a/cobra/mit/request.py
+++ b/cobra/mit/request.py
@@ -246,7 +246,7 @@ class AbstractQuery(AbstractRequest):
 
     @classFilter.setter
     def classFilter(self, value):
-        if isinstance(value, str):
+        if not isinstance(value, list):
             value = value.split(',')
 
         value = [name.replace('.', '') for name in value]

--- a/cobra/mit/session.py
+++ b/cobra/mit/session.py
@@ -489,4 +489,4 @@ class CertSession(AbstractSession):
                      " APIC-Certificate-Algorithm=v1.0;" +
                      " APIC-Certificate-Fingerprint=fingerprint;" +
                      " APIC-Certificate-DN=%s")
-        return cookieFmt % (signature, certDn)
+        return cookieFmt % (str(signature), certDn)

--- a/cobra/mit/session.py
+++ b/cobra/mit/session.py
@@ -442,8 +442,9 @@ class CertSession(AbstractSession):
                 payLoad = 'POST' + uri + data
 
             pkey = load_privatekey(FILETYPE_PEM, privateKeyStr)
+
             signedDigest = sign(pkey, payLoad.encode(), 'sha256')
-            signature = base64.b64encode(signedDigest)
+            signature = base64.b64encode(signedDigest).decode()
         else:
             tmpFiles = []
             tempDir = tempfile.mkdtemp()
@@ -489,4 +490,4 @@ class CertSession(AbstractSession):
                      " APIC-Certificate-Algorithm=v1.0;" +
                      " APIC-Certificate-Fingerprint=fingerprint;" +
                      " APIC-Certificate-DN=%s")
-        return cookieFmt % (signature.decode(), certDn)
+        return cookieFmt % (signature, certDn)

--- a/cobra/mit/session.py
+++ b/cobra/mit/session.py
@@ -489,4 +489,4 @@ class CertSession(AbstractSession):
                      " APIC-Certificate-Algorithm=v1.0;" +
                      " APIC-Certificate-Fingerprint=fingerprint;" +
                      " APIC-Certificate-DN=%s")
-        return cookieFmt % (str(signature), certDn)
+        return cookieFmt % (signature.decode(), certDn)

--- a/cobra/mit/session.py
+++ b/cobra/mit/session.py
@@ -442,7 +442,7 @@ class CertSession(AbstractSession):
                 payLoad = 'POST' + uri + data
 
             pkey = load_privatekey(FILETYPE_PEM, privateKeyStr)
-            signedDigest = sign(pkey, payLoad, 'sha256')
+            signedDigest = sign(pkey, payLoad.encode(), 'sha256')
             signature = base64.b64encode(signedDigest)
         else:
             tmpFiles = []

--- a/cobra/mit/session.py
+++ b/cobra/mit/session.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from builtins import str
+from builtins import object
 
 try:
     from OpenSSL.crypto import FILETYPE_PEM, load_privatekey, sign

--- a/docs/source/api-examples/tenants.py
+++ b/docs/source/api-examples/tenants.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright 2015 Cisco Systems, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -64,7 +65,7 @@ def main(host, port, user, password):
 
     # Create Vlan Namespace
     nsInfo = VMM_DOMAIN_INFO['namespace']
-    print "Creating namespace %s.." % (nsInfo['name'])
+    print("Creating namespace %s.." % (nsInfo['name']))
     fvnsVlanInstPMo = VlanInstP(uniInfraMo, nsInfo['name'], 'dynamic')
     #fvnsArgs = {'from': nsInfo['from'], 'to': nsInfo['to']}
     EncapBlk(fvnsVlanInstPMo, nsInfo['from'], nsInfo['to'], name=nsInfo['name'])
@@ -98,11 +99,11 @@ def main(host, port, user, password):
     vmmCfg = ConfigRequest()
     vmmCfg.addMo(vmmDomPMo)
     moDir.commit(vmmCfg)
-    print "VMM Domain Creation Completed."
+    print("VMM Domain Creation Completed.")
 
-    print "Starting Tenant Creation.."
+    print("Starting Tenant Creation..")
     for tenant in TENANT_INFO:
-        print "Creating tenant %s.." % (tenant['name'])
+        print("Creating tenant %s.." % (tenant['name']))
         fvTenantMo = Tenant(uniMo, tenant['name'])
         
         # Create Private Network
@@ -116,13 +117,13 @@ def main(host, port, user, password):
         
         # Create Application Profile
         for app in tenant['ap']:
-            print 'Creating Application Profile: %s' % app['name']
+            print('Creating Application Profile: %s' % app['name'])
             fvApMo = Ap(fvTenantMo, app['name'])
             
             # Create EPGs 
             for epg in app['epgs']:
                 
-                print "Creating EPG: %s..." % (epg['name']) 
+                print("Creating EPG: %s..." % (epg['name'])) 
                 fvAEPgMo = AEPg(fvApMo, epg['name'])
                 
                 # Associate EPG to Bridge Domain 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright 2015 Cisco Systems, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -86,7 +87,7 @@ try:
     apiVersion = vman.Version()
     # The full version, including alpha/beta/rc tags.
     release = apiVersion.stringify(openDelim='-', closeDelim='')
-    print "Building version {0} of the Cobra SDK documentation".format(release)
+    print("Building version {0} of the Cobra SDK documentation".format(release))
     # The short X.Y version.
     version = release.split('-')[0]
 except:

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ class PyTest(TestCommand):
         errno = pytest.main(self.test_args)
         sys.exit(errno)
 
-install_requires = ['requests']
+install_requires = ['requests', 'future']
 
 # Doc build instructions:
 # Clone the repo

--- a/tests/mit/test_request.py
+++ b/tests/mit/test_request.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python
+
+__author__ = 'mtimm'

--- a/tests/mit/test_session_CertSession.py
+++ b/tests/mit/test_session_CertSession.py
@@ -56,8 +56,8 @@ class UserObject(object):
 
 
 # Do tests for a read only user as well as a read/write (admin level) user.
-#@pytest.fixture(scope="module", params=["rouser"])
-@pytest.fixture(scope="module", params=["rouser", "rwuser"])
+#@pytest.fixture(scope="session", params=["rouser"])
+@pytest.fixture(scope="session", params=["rouser", "rwuser"])
 def userobject(request):
     param = request.param
     userobj = UserObject(user=param)
@@ -250,7 +250,7 @@ class TestCertSession:
 
     def test_get_tn(self, apics, certobject, userobject):
         apic = apics[0]
-        secure = apics[1]
+        secure = False if apics[1] == 'False' else True
         userobject.pkey = certobject.readFile(
             fileName=certobject.pkeyfile)
         session = CertSession(apic, userobject.certDn, userobject.pkey,
@@ -266,7 +266,7 @@ class TestCertSession:
 
     def test_post_tn(self, apics, certobject, userobject):
         apic = apics[0]
-        secure = apics[1]
+        secure = False if apics[1] == 'False' else True
         userobject.pkey = certobject.readFile(
             fileName=certobject.pkeyfile)
         session = CertSession(apic, userobject.certDn, userobject.pkey,

--- a/tests/mit/test_session_CertSession.py
+++ b/tests/mit/test_session_CertSession.py
@@ -1,3 +1,5 @@
+from builtins import str
+from builtins import object
 # Copyright 2015 Cisco Systems, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -229,7 +231,7 @@ def apics(request):
 
 # Only do the tests that pass, once one fails, skip the rest
 @pytest.mark.incremental
-class TestCertSession:
+class TestCertSession(object):
 
     def test_cert_setup(self, certobject):
         # Ensure that the setup fixture does its job

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1,6 +1,3 @@
-from future import standard_library
-standard_library.install_aliases()
-from builtins import object
 # Copyright 2015 Cisco Systems, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +12,10 @@ from builtins import object
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/usr/bin/env python
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
+
 import pytest
 import logging
 import inspect

--- a/tests/model/test_model.py
+++ b/tests/model/test_model.py
@@ -1,3 +1,6 @@
+from future import standard_library
+standard_library.install_aliases()
+from builtins import object
 # Copyright 2015 Cisco Systems, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,7 +20,7 @@ import pytest
 import logging
 import inspect
 import pkgutil
-import httplib
+import http.client
 
 cobra.model = pytest.importorskip("cobra.model")
 import cobra.mit.access
@@ -28,7 +31,7 @@ pytestmark = pytest.mark.skipif(pytest.config.getvalue('apic') == [],
                                        "option on the CLI")
 slow = pytest.mark.slow
 
-httplib.HTTPConnection.debuglevel = 1
+http.client.HTTPConnection.debuglevel = 1
 logging.basicConfig(level=logging.DEBUG)
 
 
@@ -62,7 +65,7 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize('cobraclass', classlist())
 
 
-class Test_cobra_model:
+class Test_cobra_model(object):
 
     @slow
     def test_class_loader(self, moDir, cobraclass):

--- a/tests/moimpl/test_moimpl.py
+++ b/tests/moimpl/test_moimpl.py
@@ -1,3 +1,5 @@
+from builtins import str
+from builtins import object
 # Copyright 2015 Cisco Systems, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +18,7 @@ import pytest
 from cobra.internal.base.moimpl import MoStatus, BaseMo
 
 @pytest.mark.internal_base_moimpl_MoStatus
-class Test_internal_base_moimpl_MoStatus:
+class Test_internal_base_moimpl_MoStatus(object):
     # Test the expected MoStatus flags
     @pytest.mark.parametrize("status,value", [
         (MoStatus.CLEAR, 1),
@@ -114,7 +116,7 @@ class Test_internal_base_moimpl_MoStatus:
         assert status1 == status2
 
 @pytest.mark.internal_base_moimpl_MoBase
-class Test_internal_base_moimpl_MoBase:
+class Test_internal_base_moimpl_MoBase(object):
 
     # Must be called with some other class, otherwise it raises a
     # NotImplementedError

--- a/tests/moimpl/test_moimpl.py
+++ b/tests/moimpl/test_moimpl.py
@@ -1,5 +1,3 @@
-from builtins import str
-from builtins import object
 # Copyright 2015 Cisco Systems, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,8 +12,12 @@ from builtins import object
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from builtins import str
+from builtins import object
+
 import pytest
 from cobra.internal.base.moimpl import MoStatus, BaseMo
+
 
 @pytest.mark.internal_base_moimpl_MoStatus
 class Test_internal_base_moimpl_MoStatus(object):

--- a/tests/rest/test_rest.py
+++ b/tests/rest/test_rest.py
@@ -1,4 +1,9 @@
 from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import range
+from builtins import object
 # Copyright 2015 Cisco Systems, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,7 +19,7 @@ from __future__ import print_function
 # limitations under the License.
 
 #!/usr/bin/env python
-import httplib
+import http.client
 import os
 import pytest
 import random
@@ -30,6 +35,8 @@ from cobra.internal.codec.xmlcodec import toXMLStr, fromXMLStr
 import cobra.mit.access
 import cobra.mit.request
 import cobra.mit.session
+cobra = pytest.importorskip("cobra")
+cobra.model = pytest.importorskip("cobra.model")
 cobra.model.fv = pytest.importorskip("cobra.model.fv")
 import cobra.model.pol
 import cobra.model.infra
@@ -40,7 +47,7 @@ pytestmark = pytest.mark.skipif(pytest.config.getvalue('apic') == [],
                                        "option on the CLI")
 slow = pytest.mark.slow
 
-httplib.HTTPConnection.debuglevel = 1
+http.client.HTTPConnection.debuglevel = 1
 logging.basicConfig(level=logging.DEBUG)
 
 fakeDevicePackageZip = 'Archive.zip'
@@ -58,7 +65,7 @@ def moDir(request):
     return md
 
 
-class Test_rest_configrequest:
+class Test_rest_configrequest(object):
 
     def test_createtenant(self, moDir, tenantname):
         """
@@ -106,7 +113,7 @@ class Test_rest_configrequest:
         assert not tenant
 
 
-class Test_rest_classquery:
+class Test_rest_classquery(object):
 
     def test_classquery_shorthand_filter(self, moDir):
         """
@@ -203,7 +210,7 @@ class Test_rest_classquery:
         assert len(tenant) == 0
 
 
-class Test_rest_dnquery:
+class Test_rest_dnquery(object):
 
     def test_dnquery_normal(self, moDir, dn):
 
@@ -223,7 +230,7 @@ class Test_rest_dnquery:
         assert commonTn.dn == dn
 
 
-class Test_rest_login:
+class Test_rest_login(object):
 
     def test_login_positive(self, apic):
         """
@@ -287,7 +294,7 @@ class Test_rest_login:
         assert moDir._accessImpl._session.refreshTimeoutSeconds > 0
 
 
-class Test_rest_tracequery:
+class Test_rest_tracequery(object):
 
     @pytest.mark.parametrize("cls", [
         pytest.mark.skipif(pytest.config.getvalue('apic') == [],
@@ -317,7 +324,7 @@ class Test_rest_tracequery:
         assert traceResponse > 0
 
 
-class Test_services_devicepackage:
+class Test_services_devicepackage(object):
 
     fakePackage = os.path.join(os.path.dirname(os.path.realpath(__file__)),
                                fakeDevicePackageZip)

--- a/tests/rest/test_rest.py
+++ b/tests/rest/test_rest.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright 2015 Cisco Systems, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -308,10 +309,10 @@ class Test_rest_tracequery:
 
         for node in nodes:
             a = cobra.mit.request.TraceQuery(node.dn, cls)
-            print a.getUrl(moDir._accessImpl._session)
+            print(a.getUrl(moDir._accessImpl._session))
             mos = moDir.query(a)
             for mo in mos:
-                print mo.dn
+                print(mo.dn)
             traceResponse += len(mos)
         assert traceResponse > 0
 

--- a/tests/rest/test_rest.py
+++ b/tests/rest/test_rest.py
@@ -91,7 +91,7 @@ class Test_rest_configrequest(object):
 
         mo = mos[0]
         assert len(mos) > 0
-        assert mo.dn == tenant.dn
+        assert str(mo.dn) == str(tenant.dn)
         assert len(list(mo.children)) >= 1
 
     def test_lookupcreatedtenant(self, moDir, tenantname):
@@ -124,7 +124,7 @@ class Test_rest_classquery(object):
             'fvTenant', propFilter='eq(fvTenant.name, "common")')
         assert len(commonTn) == 1
         commonTn = commonTn[0]
-        assert commonTn.dn == 'uni/tn-common'
+        assert str(commonTn.dn) == 'uni/tn-common'
 
     def test_classquery_normal(self, moDir):
         """
@@ -152,7 +152,7 @@ class Test_rest_classquery(object):
         classQuery.propFilter = 'eq(fvTenant.name, "common")'
         commonTn = moDir.query(classQuery)
         commonTn = commonTn[0]
-        assert commonTn.dn == 'uni/tn-common'
+        assert str(commonTn.dn) == 'uni/tn-common'
 
     def test_classquery_subtree(self, moDir):
         """
@@ -163,10 +163,10 @@ class Test_rest_classquery(object):
         classQuery.propFilter = 'eq(fvTenant.name, "common")'
         commonTn = moDir.query(classQuery)
         commonTn = commonTn[0]
-        assert commonTn.dn == 'uni/tn-common'
+        assert str(commonTn.dn) == 'uni/tn-common'
         # expect at least 3 child objects
         assert len(list(commonTn.children)) >= 3
-        assert commonTn.BD['default'].dn == 'uni/tn-common/BD-default'
+        assert str(commonTn.BD['default'].dn) == 'uni/tn-common/BD-default'
 
     @pytest.mark.parametrize("cls,subtree", [
         pytest.mark.skipif(pytest.config.getvalue('apic') == [],
@@ -203,7 +203,7 @@ class Test_rest_classquery(object):
         """
         generate a random tenant name and ensure that we dont find a match for it
         """
-        tenantName = ''.join(random.choice(string.lowercase)
+        tenantName = ''.join(random.choice(string.ascii_lowercase)
                              for i in range(64))
         tenant = moDir.lookupByClass(
             'fvTenant', propFilter='eq(fvTenant.name, "{0}")'.format(tenantName))
@@ -220,14 +220,14 @@ class Test_rest_dnquery(object):
         commonTn = moDir.query(dnQuery)
         assert len(commonTn) == 1
         commonTn = commonTn[0]
-        assert commonTn.dn == dn
+        assert str(commonTn.dn) == str(dn)
         # expect at least 3 child objects
         assert len(list(commonTn.children)) >= 3
-        assert commonTn.BD['default'].dn == 'uni/tn-common/BD-default'
+        assert str(commonTn.BD['default'].dn) == 'uni/tn-common/BD-default'
 
     def test_dnquery_shorthand(self, moDir, dn):
         commonTn = moDir.lookupByDn(dn)
-        assert commonTn.dn == dn
+        assert str(commonTn.dn) == str(dn)
 
 
 class Test_rest_login(object):

--- a/tests/rest/test_rest.py
+++ b/tests/rest/test_rest.py
@@ -1,9 +1,3 @@
-from __future__ import print_function
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
-from builtins import range
-from builtins import object
 # Copyright 2015 Cisco Systems, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +12,13 @@ from builtins import object
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/usr/bin/env python
+from __future__ import print_function
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import range
+from builtins import object
+
 import http.client
 import os
 import pytest

--- a/tests/rest/test_rest_mock.py
+++ b/tests/rest/test_rest_mock.py
@@ -1,3 +1,7 @@
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import object
 # Copyright 2015 Cisco Systems, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,7 +23,7 @@ import time
 import logging
 import logging.handlers
 import responses
-import httplib
+import http.client
 import json
 
 from cobra.internal.codec.jsoncodec import fromJSONStr, toJSONStr
@@ -38,7 +42,7 @@ import cobra.model.fv
 import cobra.model.pol
 import cobra.model.infra
 
-httplib.HTTPConnection.debuglevel = 1
+http.client.HTTPConnection.debuglevel = 1
 
 logging.basicConfig()
 logger = logging.getLogger()
@@ -191,7 +195,7 @@ def moDir(getResponseMock, apic):
     return md
 
 
-class Test_rest_login:
+class Test_rest_login(object):
 
     def test_login_positive(self, apic, getResponseMock):
         """
@@ -215,7 +219,7 @@ class Test_rest_login:
             getResponseMock.stop()
 
 
-class Test_rest_configrequest:
+class Test_rest_configrequest(object):
 
     def test_createtenant(self, moDir, apic, tenantname, getResponseMock):
         """
@@ -312,7 +316,7 @@ class Test_rest_configrequest:
             getResponseMock.stop()
 
 
-class Test_rest_classquery:
+class Test_rest_classquery(object):
 
     def test_classquery_normal(self, moDir, apic, getResponseMock):
         """

--- a/tests/rest/test_rest_mock.py
+++ b/tests/rest/test_rest_mock.py
@@ -245,7 +245,7 @@ class Test_rest_configrequest(object):
         logger.debug('commit response {0}'.format(r.content))
         assert r.status_code == 200
 
-        mos = fromJSONStr(r.content)
+        mos = fromJSONStr(str(r.text))
         mo = mos[0]
         logger.debug('r.content: {0}'.format(r.content))
         assert len(mos) > 0
@@ -279,7 +279,7 @@ class Test_rest_configrequest(object):
             'fvTenant', propFilter='eq(fvTenant.name, "{0}")'.format(tenantname))
         assert len(Tn) == 1
         Tn = Tn[0]
-        assert Tn.dn == 'uni/tn-{0}'.format(tenantname)
+        assert str(Tn.dn) == 'uni/tn-{0}'.format(tenantname)
 
         if apic[0] == 'http://mock':
             getResponseMock.stop()

--- a/tests/rest/test_rest_mock.py
+++ b/tests/rest/test_rest_mock.py
@@ -1,7 +1,3 @@
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
-from builtins import object
 # Copyright 2015 Cisco Systems, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +12,11 @@ from builtins import object
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-#!/usr/bin/env python
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import object
+
 import os
 import pytest
 import time

--- a/tests/session/test_session.py
+++ b/tests/session/test_session.py
@@ -1,3 +1,4 @@
+from builtins import object
 # Copyright 2015 Cisco Systems, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,7 +28,7 @@ with open(join(CERT_DIR, KEY_FILE), "r") as file:
     KeyPEMdata = file.read()
 
 @pytest.mark.mit_session_Success_LoginSession
-class Test_mit_session_Success_LoginSession:
+class Test_mit_session_Success_LoginSession(object):
     # Test the properties get set properly on LoginSession instantiation
     @pytest.mark.parametrize("session, url, user, password, secure, timeout,"
                              "requestFormat", [
@@ -48,7 +49,7 @@ class Test_mit_session_Success_LoginSession:
        assert session.formatStr == requestFormat
 
 @pytest.mark.mit_session_Raises_LoginSession
-class Test_mit_session_Raises_LoginSession:
+class Test_mit_session_Raises_LoginSession(object):
     # Test that LoginSession raises an exception when passed an invalid property
     @pytest.mark.parametrize("url, user, password, secure, timeout,"
                               "requestFormat", [
@@ -61,7 +62,7 @@ class Test_mit_session_Raises_LoginSession:
                          requestFormat=requestFormat)
 
 @pytest.mark.mit_session_CertSession
-class Test_mit_session_CertSession:
+class Test_mit_session_CertSession(object):
     def test_CertSession_init_xml(self):
         # Did not parametrize it  because doing so causes a huge amount of output
         # from the private key
@@ -134,7 +135,7 @@ class Test_mit_session_CertSession:
                              'ert-auserCert')
 
 @pytest.mark.mit_session_Raises_CertSession
-class Test_mit_session_Raises_CertSession:
+class Test_mit_session_Raises_CertSession(object):
     # Test that CertSession raises an exception when passed an invalid property
     def test_CertSession_init_raises(self):
         with pytest.raises(NotImplementedError):

--- a/tests/session/test_session.py
+++ b/tests/session/test_session.py
@@ -1,4 +1,3 @@
-from builtins import object
 # Copyright 2015 Cisco Systems, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +11,8 @@ from builtins import object
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from builtins import object
 
 from os.path import join, dirname, realpath
 import pytest


### PR DESCRIPTION
This depends on the future module. There are still outstanding issues that I know of:
1. From time to time doing a full subtree query of topSystem results in a ValueError when modifying a child Mo.
   For my testbed it is always when adding a key to eqptcap.SfpMfgDef for the naming value.
2. shippable.yml needs to be updated to run tests on python3. I'll be adding that next.

Working on #20 and closes #21
