### PR TITLE
chore(ci): add caching of minions for shippable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+cache: true
 # command to install dependencies
 install: 
   - "pip install requests"


### PR DESCRIPTION
This should cache dependancies so they don't have
to be installed on every build.

Closes #33
