### PR TITLE
fix(accessimpl): handle redirects during login

### DIFF
--- a/cobra/internal/rest/accessimpl.py
+++ b/cobra/internal/rest/accessimpl.py
@@ -52,7 +52,8 @@ class LoginRequest(AbstractRequest):
             'headers': headers,
             'verify': session.secure,
             'data': self.data,
-            'timeout': session.timeout
+            'timeout': session.timeout,
+            'allow_redirects': False
         }
         return kwargs
 
@@ -85,6 +86,11 @@ class LoginHandler(object):
         loginRequest = LoginRequest(session.user, session.password)
         url = loginRequest.getUrl(session)
         rsp = requests.post(url, **loginRequest.requestargs(session))
+        # handle a redirect, for example from http to https
+        while rsp.status_code in (requests.codes.moved, requests.codes.found):
+            session.url = rsp.headers['Location'].rstrip('/api/aaaLogin.json')
+            cls.login(session)
+            return
         session._parseResponse(rsp)
 
     @classmethod

--- a/cobra/mit/session.py
+++ b/cobra/mit/session.py
@@ -89,6 +89,11 @@ class AbstractSession(object):
     def url(self):
         return self.__controllerUrl
 
+    @url.setter
+    def url(self, value):
+        # Allow setting of the controller URL to be able to handle redirects
+        self.__controllerUrl = value
+
     @property
     def formatType(self):
         return self.__format


### PR DESCRIPTION
For a redirected POST, requests follows what browsers do and redirects to the
new location but uses a GET during the redirect.  If the endpoint has redirect
enabled for http to https, this behavior can be problematic since our first
interaction with the endpoint may be a login request which is a POST.

When a redirect occurs during login the new location can be used to update the
session url so future interaction with the endpoint works as expected, assuming
the secure option is set properly by the user.

Closes #56
