### PR TITLE
feature(aaaListDomains): add support for aaaListDomains query prior to login

### DIFF
--- a/cobra/mit/access.py
+++ b/cobra/mit/access.py
@@ -30,6 +30,10 @@ class MoDirectory(object):
     """Creates a connection to the APIC and the MIT.
 
     MoDirectory requires an existing session.
+
+    Attributes:
+      session (cobra.mit.session.AbstractSession): The session tied to this
+        MoDirectory instance.
     """
 
     def __init__(self, session):
@@ -41,13 +45,23 @@ class MoDirectory(object):
         """
         self._session = session
 
+    @property
+    def session(self):
+        """Get the session for this MoDirectory instance.
+
+        Returns:
+          cobra.mit.session.AbstractSession: The session tied to this
+          MoDirectory instance.
+        """
+        return self._session
+
     def login(self):
         """Create a session to an APIC."""
-        self._session.login()
+        self.session.login()
 
     def logout(self):
         """End a session to an APIC."""
-        self._session.logout()
+        self.session.logout()
 
     def reauth(self):
         """Re-authenticate the session with the current authentication cookie.
@@ -57,7 +71,7 @@ class MoDirectory(object):
         the server side. If this method fails, the user must login again to
         authenticate and effectively create a new session.
         """
-        self._session.refresh()
+        self.session.refresh()
 
     def query(self, queryObject):
         """Query the Model Information Tree.
@@ -72,7 +86,7 @@ class MoDirectory(object):
           list: A list of Managed Objects (MOs) returned from the query
         """
         try:
-            rsp = self._session.get(queryObject)
+            rsp = self.session.get(queryObject)
             return self.__parseResponse(rsp)
         except RestError as ex:
             self.__parseError(ex.reason, QueryError, ex.httpCode)
@@ -94,7 +108,7 @@ class MoDirectory(object):
           CommitError: If no MOs have been added to the config request
         """
         try:
-            rsp = self._session.post(configObject)
+            rsp = self.session.post(configObject)
             return self.__parseResponse(rsp)
         except RestError as ex:
             self.__parseError(ex.reason, CommitError, ex.httpCode)
@@ -166,7 +180,7 @@ class MoDirectory(object):
           Exception: The errorClass.
 
         """
-        self._session.codec.error(rsp, errorClass, httpCode)
+        self.session.codec.error(rsp, errorClass, httpCode)
 
     def __parseResponse(self, rsp):
         """Parse a response.
@@ -177,7 +191,7 @@ class MoDirectory(object):
         Returns:
           cobra.mit.mo.Mo: The response parsed into a managed object.
         """
-        return self._session.codec.fromStr(rsp)
+        return self.session.codec.fromStr(rsp)
 
     @staticmethod
     def __setQueryParams(query, queryParams):

--- a/cobra/mit/access.py
+++ b/cobra/mit/access.py
@@ -30,10 +30,6 @@ class MoDirectory(object):
     """Creates a connection to the APIC and the MIT.
 
     MoDirectory requires an existing session.
-
-    Attributes:
-      session (cobra.mit.session.AbstractSession): The session tied to this
-        MoDirectory instance.
     """
 
     def __init__(self, session):
@@ -45,23 +41,13 @@ class MoDirectory(object):
         """
         self._session = session
 
-    @property
-    def session(self):
-        """Get the session for this MoDirectory instance.
-
-        Returns:
-          cobra.mit.session.AbstractSession: The session tied to this
-          MoDirectory instance.
-        """
-        return self._session
-
     def login(self):
         """Create a session to an APIC."""
-        self.session.login()
+        self._session.login()
 
     def logout(self):
         """End a session to an APIC."""
-        self.session.logout()
+        self._session.logout()
 
     def reauth(self):
         """Re-authenticate the session with the current authentication cookie.
@@ -71,7 +57,7 @@ class MoDirectory(object):
         the server side. If this method fails, the user must login again to
         authenticate and effectively create a new session.
         """
-        self.session.refresh()
+        self._session.refresh()
 
     def query(self, queryObject):
         """Query the Model Information Tree.
@@ -86,7 +72,7 @@ class MoDirectory(object):
           list: A list of Managed Objects (MOs) returned from the query
         """
         try:
-            rsp = self.session.get(queryObject)
+            rsp = self._session.get(queryObject)
             return self.__parseResponse(rsp)
         except RestError as ex:
             self.__parseError(ex.reason, QueryError, ex.httpCode)
@@ -108,7 +94,7 @@ class MoDirectory(object):
           CommitError: If no MOs have been added to the config request
         """
         try:
-            rsp = self.session.post(configObject)
+            rsp = self._session.post(configObject)
             return self.__parseResponse(rsp)
         except RestError as ex:
             self.__parseError(ex.reason, CommitError, ex.httpCode)
@@ -180,7 +166,7 @@ class MoDirectory(object):
           Exception: The errorClass.
 
         """
-        self.session.codec.error(rsp, errorClass, httpCode)
+        self._session.codec.error(rsp, errorClass, httpCode)
 
     def __parseResponse(self, rsp):
         """Parse a response.
@@ -191,7 +177,7 @@ class MoDirectory(object):
         Returns:
           cobra.mit.mo.Mo: The response parsed into a managed object.
         """
-        return self.session.codec.fromStr(rsp)
+        return self._session.codec.fromStr(rsp)
 
     @staticmethod
     def __setQueryParams(query, queryParams):

--- a/cobra/mit/request.py
+++ b/cobra/mit/request.py
@@ -548,7 +548,7 @@ class LoginRequest(AbstractRequest):
 
 class ListDomainsRequest(AbstractRequest):
 
-    """A class to get the possible security domains prior to login"""
+    """A class to get the possible security domains prior to login."""
 
     def __init__(self):
         """Instantiate a ListDomainsRequest instance."""

--- a/cobra/mit/request.py
+++ b/cobra/mit/request.py
@@ -546,11 +546,33 @@ class LoginRequest(AbstractRequest):
         return session.url + self.uriBase
 
 
+class ListDomainsRequest(AbstractRequest):
+
+    """A class to get the possible security domains prior to login"""
+
+    def __init__(self):
+        """Instantiate a ListDomainsRequest instance."""
+        super(ListDomainsRequest, self).__init__()
+        self.uriBase = '/api/aaaListDomains.json'
+
+    def getUrl(self, session):
+        """Get the URL containing all the options if any.
+
+        Args:
+          session (cobra.mit.session.AbstractSession): The session to use for
+            this request.
+
+        Returns:
+          str: The url
+        """
+        return session.url + self.uriBase
+
+
 class RefreshRequest(AbstractRequest):
 
     """Session refresh request.
 
-    Does standard user/password based authentication.
+    Does standard user/password based re-authentication.
     """
 
     def __init__(self, cookie):
@@ -560,11 +582,11 @@ class RefreshRequest(AbstractRequest):
         self.uriBase = '/api/aaaRefresh.json'
 
     def getUrl(self, session):
-        """Get the URL containing all the query options.
+        """Get the URL containing all the  options if any.
 
         Args:
           session (cobra.mit.session.AbstractSession): The session to use for
-            this query.
+            this request.
 
         Returns:
           str: The url

--- a/cobra/mit/session.py
+++ b/cobra/mit/session.py
@@ -232,6 +232,7 @@ class LoginError(Exception):
         return self.reason
 
 
+# pylint:disable=too-many-instance-attributes
 class LoginSession(AbstractSession):
 
     """A login session with a username and password.
@@ -314,7 +315,7 @@ class LoginSession(AbstractSession):
 
     @property
     def user(self):
-        """Get the username being used for this session.
+        r"""Get the username being used for this session.
 
         This can not be changed.  If you need to change the session username,
         instantiate a new session object.
@@ -441,7 +442,7 @@ class LoginSession(AbstractSession):
 
     @loginDomain.setter
     def loginDomain(self, domain):
-        """Set the loginDomain.
+        r"""Set the loginDomain.
 
         When the loginDomain is not an empty string or 'DefaultAuth', the
         username of the session will be modified to:
@@ -546,7 +547,7 @@ class LoginSession(AbstractSession):
             # Handle aaaLoginDomain response which has an odd format.
             self._domains = []
             for domain in data:
-                self._domains.append( domain['name'])
+                self._domains.append(domain['name'])
                 if domain['name'] == 'DefaultAuth':
                     self._banner = domain['guiBanner']
         else:
@@ -660,7 +661,7 @@ class CertSession(AbstractSession):
         pass
 
     def getLoginDomains(self):
-        """getLoginDomains method.
+        """The getLoginDomains method.
 
         Not (yet) relevant for CertSession but is included for consistency.
         """

--- a/tests/rest/test_rest.py
+++ b/tests/rest/test_rest.py
@@ -224,6 +224,29 @@ class Test_rest_dnquery(object):
         assert str(commonTn.dn) == str(dn)
 
 
+class Test_rest_getLoginDomains(object):
+
+    def test_getDomains(self, apic):
+        """Verify that the getLoginDomains() method works.
+        """
+        url, user, password, secure = apic
+        secure = False if secure == 'False' else True
+        session = cobra.mit.session.LoginSession(url, user, password,
+                                                 secure=secure)
+        session.getLoginDomains()
+        assert session.domains != []
+
+    def test_loginDomains_setting(self, apic):
+        """Verify that the loginDomain can be set."""
+        url, user, password, secure = apic
+        secure = False if secure == 'False' else True
+        session = cobra.mit.session.LoginSession(url, user, password,
+                                                 secure=secure)
+        session.getLoginDomains()
+        session.loginDomain = session.domains[0]
+        assert session.loginDomain == session.domains[0]
+
+
 class Test_rest_login(object):
 
     def test_login_positive(self, apic):

--- a/tests/rest/test_rest_mock.py
+++ b/tests/rest/test_rest_mock.py
@@ -85,6 +85,19 @@ def getResponseMock(tenantname, apic):
                 ]
             }
         ),
+        'aaaListDomains': json.dumps(
+            {
+                'imdata': [
+                    {
+                        'name': 'fakeDomain'
+                    },
+                    {
+                        'name': 'DefaultAuth',
+                        'guiBanner': 'fakeBanner'
+                    }
+                ]
+            }
+        ),
         'tenant': json.dumps(
             {
                 'imdata': [
@@ -138,6 +151,13 @@ def getResponseMock(tenantname, apic):
             'args': [responses.POST],
             'kwargs': {
                 'body': CONTENT['aaaLogin'],
+                'adding_headers': HEADERS
+            }
+        }),
+        ('{0}/api/aaaListDomains.json'.format(url), {
+            'args': [responses.GET],
+            'kwargs': {
+                'body': CONTENT['aaaListDomains'],
                 'adding_headers': HEADERS
             }
         }),
@@ -200,6 +220,36 @@ def moDir(getResponseMock, apic):
     if apic[0] == 'http://mock':
         getResponseMock.stop()
     return md
+
+
+class Test_rest_getLoginDomains(object):
+
+    def test_getLoginDomains_domains_islist(self, apic, getResponseMock):
+        """Verify that the getLoginDomains method works."""
+        if apic[0] == 'http://mock':
+            getResponseMock.start()
+        url, user, password, secure = apic
+
+        secure = False if secure == 'False' else True
+        session = cobra.mit.session.LoginSession(url, user, password,
+                                                 secure=secure,
+                                                 requestFormat='json')
+        session.getLoginDomains()
+        assert isinstance(session.domains, list)
+
+    def test_getLoginDomains_domains(self, apic, getResponseMock):
+        """Verify that the getLoginDomains method works."""
+        if apic[0] == 'http://mock':
+            getResponseMock.start()
+        url, user, password, secure = apic
+
+        secure = False if secure == 'False' else True
+        session = cobra.mit.session.LoginSession(url, user, password,
+                                                 secure=secure,
+                                                 requestFormat='json')
+        session.getLoginDomains()
+        # Currently the APIC ALWAYS returns DefaultAuth in the results
+        assert len(session.domains) > 0
 
 
 class Test_rest_login(object):


### PR DESCRIPTION
This also adds support for updating the username used for a session if the session.loginDomain property is set to support logging in using a specific login domain.

Closes #7 
