### PR TITLE
feature(upload): add firmware upload request

### DIFF
--- a/cobra/internal/codec/xmlcodec.py
+++ b/cobra/internal/codec/xmlcodec.py
@@ -41,12 +41,16 @@ def parseXMLError(rspStr, errorClass, httpCode=None):
           to will be raised.
         ValueError: If the response can not be parsed.
     """
-    errorNode = ET.fromstring(rspStr).find('error')
+    try:
+        errorNode = ET.fromstring(rspStr).find('error')
+    except ET.ParseError as ex:
+        # 404 error can end up here, however since the response is html it is
+        # partially parsed, then the xml parser fails
+        raise ValueError(rspStr)
     if errorNode is not None:
         errorStr = errorNode.attrib['text']
         errorCode = errorNode.attrib['code']
         raise errorClass(int(errorCode), errorStr, httpCode)
-
     raise ValueError(rspStr)
 
 

--- a/cobra/mit/session.py
+++ b/cobra/mit/session.py
@@ -498,7 +498,10 @@ class LoginSession(AbstractSession):
         The domains are returned as a list.
         """
         domainsRequest = ListDomainsRequest()
-        rsp = self._accessimpl.get(domainsRequest)
+        try:
+            rsp = self._accessimpl.get(domainsRequest)
+        except RestError as ex:
+            self._parseResponse(ex.reason)
         self._parseResponse(rsp)
 
     def refresh(self):
@@ -509,7 +512,10 @@ class LoginSession(AbstractSession):
             the response could not be parsed.
         """
         refreshRequest = RefreshRequest(self.cookie)
-        rsp = self._accessimpl.get(refreshRequest)
+        try:
+            rsp = self._accessimpl.get(refreshRequest)
+        except:
+            self._parseResponse(ex.reason)
         self._parseResponse(rsp)
 
     def _parseResponse(self, rsp):
@@ -525,7 +531,7 @@ class LoginSession(AbstractSession):
         rspDict = json.loads(rsp)
         data = rspDict.get('imdata', None)
         if not data:
-            raise LoginError(0, 'Bad Response: ' + str(rsp.text))
+            raise LoginError(0, 'Bad Response: ' + str(rsp))
 
         firstRecord = data[0]
         if 'error' in firstRecord:
@@ -551,7 +557,7 @@ class LoginSession(AbstractSession):
                 if domain['name'] == 'DefaultAuth':
                     self._banner = domain['guiBanner']
         else:
-            raise LoginError(0, 'Bad Response: ' + str(rsp.text))
+            raise LoginError(0, 'Bad Response: ' + str(rsp))
 
 
 class CertSession(AbstractSession):

--- a/docs/source/api-ref/request.rst
+++ b/docs/source/api-ref/request.rst
@@ -116,6 +116,15 @@ Class that represents a request to refresh a session.
    :members:
    :special-members:
 
+FwUploadRequest
+---------------
+
+Class that represents a request to upload firmware to an APIC.
+
+.. autoclass:: cobra.mit.request.RefreshRequest
+   :members:
+   :special-members:
+
 DnQuery
 -------
 

--- a/tests/mit/test_request.py
+++ b/tests/mit/test_request.py
@@ -21,7 +21,8 @@ from cobra.mit.request import (AbstractRequest, AbstractQuery, LoginRequest,
                                RefreshRequest, ListDomainsRequest, DnQuery,
                                ClassQuery, TraceQuery, TagsRequest,
                                AliasRequest, ConfigRequest, MultiQuery,
-                               TroubleshootingQuery, CommitError)
+                               TroubleshootingQuery, CommitError,
+                               FwUploadRequest)
 from cobra.mit.session import LoginSession
 cobra.model = pytest.importorskip('cobra.model')
 from cobra.model.pol import Uni
@@ -274,6 +275,26 @@ class Test_mit_request_ListDomainsRequest(object):
         expected = sessionUrl + '/api/aaaListDomains.json'
         ldr = ListDomainsRequest()
         assert ldr.getUrl(session) == expected
+
+
+@pytest.mark.mit_request_FwUploadRequest
+class Test_mit_request_FwUploadRequest(object):
+
+    def test_FwUploadRequest_init(self):
+        assert isinstance(FwUploadRequest('dummy'), FwUploadRequest)
+
+    @pytest.mark.parametrize("sessionUrl, requestType", [
+        ("http://1.1.1.1", 'xml'),
+        ("http://2.2.2.2", 'json'),
+        ("http://3.3.3.3", 'xml'),
+        ("http://4.4.4.4", 'json'),
+   ])
+    def test_FwUploadRequest_getUrl(self, sessionUrl, requestType):
+        session = LoginSession(sessionUrl, 'admin', 'password',
+                               requestFormat=requestType)
+        expected = sessionUrl + '/fwupload/.' + requestType
+        fur = FwUploadRequest('dummy')
+        assert fur.getUrl(session) == expected
 
 
 @pytest.mark.mit_request_DnQuery


### PR DESCRIPTION
Also I found some issues with the xml codec if the request returns non-xml
- for example html for 404 errors - the xml codec would try to parse it and
  fail in a non-obvious way.  I addressed this by looking for the failure to
  parse and raising ValueError instead.  The JSON codec fails with a
  ValueError in this situation as it is.

Closes #69
