### PR TITLE
docs: covert all examples in docs to python terminal output

### DIFF
--- a/docs/source/api-examples/index.rst
+++ b/docs/source/api-examples/index.rst
@@ -25,12 +25,13 @@ in any APIC Python API program using these code examples.
 
 .. code-block:: python
 
-   from cobra.mit.access import MoDirectory
-   from cobra.mit.session import LoginSession
-   session = LoginSession('https://sample-host.coolapi.com', 'admin',
-                          'xxx?xxx?xxx')
-   moDir = MoDirectory(session)
-   moDir.login()
+    >>> from cobra.mit.session import LoginSession
+    >>> from cobra.mit.access import MoDirectory
+    >>> 
+    >>> session = LoginSession('https://10.10.10.100', 'user', 'password')
+    >>> moDir = MoDirectory(session) 
+    >>> moDir.login()
+    >>> 
 
 The above code snippet creates an **MoDirectory**, connects it to the endpoint
 and then performs authentication. The **moDir** can be used to query,
@@ -50,18 +51,24 @@ resolution universe ('uni') class. This example creates a tenant named
 
 .. code-block:: python
 
-   # Import the config request
-   from cobra.mit.request import ConfigRequest
-   configReq = ConfigRequest()
 
-   # Import the tenant class from the model
-   from cobra.model.fv import Tenant
-
-   # Get the top level policy universe directory
-   uniMo = moDir.lookupByDn('uni')
-
-   # create the tenant object
-   fvTenantMo = Tenant(uniMo, 'ExampleCorp')
+    >>> # Import the config request class
+    ... 
+    >>> from cobra.mit.request import ConfigRequest
+    >>> configReq = ConfigRequest()
+    >>> 
+    >>> # Import the tenant class from the model
+    ... 
+    >>> from cobra.model.fv import Tenant
+    >>> 
+    >>> # Get the top level policy universe directory
+    ... 
+    >>> uniMo = moDir.lookupByDn('uni')
+    >>> 
+    >>> # Create the tenant object
+    ... 
+    >>> fvTenantMo = Tenant(uniMo, 'ExampleCorp')
+    >>> 
 
 The command creates an object of the fv.Tenant class and returns a reference
 to the object. A tenant contains primary elements such as filters, contracts,
@@ -80,11 +87,11 @@ tenant.
 
 .. code-block:: python
 
-   # Import the Ap class from the model
-   from cobra.model.fv import Ap
-
-   fvApMo = Ap(fvTenantMo, 'WebApp')
-
+    >>> # Import the Ap class from the model
+    ...
+    >>> from cobra.model.fv import Ap
+    >>> fvApMo = Ap(fvTenantMo, 'WebApp')
+    >>> 
 
 Endpoint Groups
 ================
@@ -96,11 +103,11 @@ an application profile under the tenant.
 
 .. code-block:: python
 
-   # Import the AEPg class from the model
-   from cobra.model.fv import AEPg
-
-   fvAEPgMoWeb = AEPg(fvApMo, 'WebEPG')
-
+    >>> # Import the AEPg class from the model
+    ... 
+    >>> from cobra.model.fv import AEPg
+    >>> fvAEPgMoWeb = AEPg(fvApMo, 'WebEPG')
+    >>> 
 
 Physical Domains
 ================
@@ -110,21 +117,26 @@ domain.
 
 .. code-block:: python
 
-   # Import the related classes from the model
-   from cobra.model.fv import RsBd, Ctx, Bd, RsCtx
-
-   # create a private network
-   fvCtxMo = Ctx(fvTenantMo, 'private-net1')
-
-   # create a bridge domain
-   fvBDMo = BD(fvTenantMo, 'bridge-domain1')
-
-   # create an association of the bridge domain to the private network
-   fvRsCtx = RsCtx(fvBDMo, tnFvCtxName=fvCtxMo.name)
-
-   # create a physical domain associated with the endpoint group
-   fvRsBd1 = RsBd(fvAEPgMoWeb, fvBDMo.name)
-
+    >>> # Import the related classes from the model    
+    ... 
+    >>> from cobra.model.fv import RsBd, Ctx, BD, RsCtx 
+    >>> 
+    >>> # Create a private network
+    ... 
+    >>> fvCtxMo = Ctx(fvTenantMo, 'private-net1')
+    >>> 
+    >>> # Create a bridge domain
+    ... 
+    >>> fvBDMo = BD(fvTenantMo, 'bridge-domain1')
+    >>> 
+    >>> # Create an association of the bridge domain to the private network
+    ... 
+    >>> fvRsCtx = RsCtx(fvBDMo, tnFvCtxName=fvCtxMo.name)
+    >>> 
+    >>> # Create a physical domain associated with the end point group
+    ... 
+    >>> fvRsBd1 = RsBd(fvAEPgMoWeb, fvBDMo.name)
+    >>> 
 
 Contracts and Filters
 ======================
@@ -138,29 +150,36 @@ This example creates a Web filter for HTTP (TCP port 80) traffic.
 
 .. code-block:: python
 
-   # Import the Filter and related classes from model
-   from cobra.model.vz import Filter, Entry, BrCP, Subj, RsSubjFiltAtt
-
-   # create a filter container (vz.Filter object) within the tenant
-   filterMo = Filter(fvTenantMo, 'WebFilter')
-
-   # create a filter entry (vz.Entry object) that specifies bidirectional
-   # HTTP (TCP/80) traffic
-   entryMo = Entry(filterMo, 'HttpPort')
-   entryMo.dFromPort = 80    # HTTP port
-   entryMo.dToPort = 80
-   entryMo.prot = 6          # TCP protocol number
-   entryMo.etherT = "ip"     # EtherType
-
-   # create a binary contract (vz.BrCP object) container within the
-   # tenant
-   vzBrCPMoHTTP = BrCP(fvTenantMo, 'WebContract')
-
-   # create a subject container for associating the filter with the
-   # contract
-   vzSubjMo = Subj(vzBrCPMoHTTP, 'WebSubject')
-   RsSubjFiltAtt(vzSubjMo, tnVzFilterName=filterMo.name)
-
+    >>> # Import the Filter and related classes from model
+    ... 
+    >>> from cobra.model.vz import Filter, Entry, BrCP, Subj, RsSubjFiltAtt
+    >>> 
+    >>> # Create a filter container (vz.Filter object) within the tenant
+    ... 
+    >>> filterMo = Filter(fvTenantMo, 'WebFilter')
+    >>> 
+    >>> # Create a filter entry (vz.Entry object) that specifies bidirectional
+    ... # HTTP (tcp/80) traffic
+    ... 
+    >>> entryMo = Entry(filterMo, 'HttpPort')
+    >>> entryMo.dfromPort = 80      # HTTP port
+    >>> entryMo.dFromPort = 80      # HTTP port
+    >>> entryMo.dToPort = 80
+    >>> entryMo.prot = 6            # TCP protocol number
+    >>> entryMo.etherT = 'ip'       # EtherType
+    >>> 
+    >>> # Create a binary contract (vz.BrCP object) container within the
+    ... # tenant
+    ... 
+    >>> vzBrCPMoHTTP = BrCP(fvTenantMo, 'WebContract')
+    >>> 
+    >>> # Create a subject container for assiciating the filter with the
+    ... # contract
+    ... 
+    >>> vzSubjMo = Subj(vzBrCPMoHTTP, 'WebSubject')  
+    >>> RsSubjFiltAtt(vzSubjMo, tnVzFilterName=filterMo.name)
+    <cobra.model.vz.RsSubjFiltAtt object at 0x7fad1fce16d0>
+    >>> 
 
 Namespaces
 ==========
@@ -172,16 +191,18 @@ creates and assigns properties to a VLAN namespace.
 
 .. code-block:: python
 
-   # Import the namespaces related classes from model
-   from cobra.model.fvns import VlanInstP, EncapBlk
-
-   fvnsVlanInstP = VlanInstP('uni/infra', 'namespace1', 'dynamic')
-   fvnsEncapBlk = EncapBlk(fvnsVlanInstP, 'vlan-5', 'vlan-20',
-                               name='encap')
-   nsCfg = ConfigRequest()
-   nsCfg.addMo(fvnsVlanInstP)
-   moDir.commit(nsCfg)
-
+    >>> # Import the namespaces related classes from model
+    ... 
+    >>> from cobra.model.fvns import VlanInstP, EncapBlk
+    >>> 
+    >>> fvnsVlanInstP = VlanInstP('uni/infra', 'namespace1', 'dynamic')
+    >>> fvnsEncapBlk = EncapBlk(fvnsVlanInstP, 'vlan-5', 'vlan-20',
+    ...                             name='encap')
+    >>> nsCfg = ConfigRequest()
+    >>> nsCfg.addMo(fvnsVlanInstP)
+    >>> moDir.commit(nsCfg)
+    <Response [200]>
+    >>> 
 
 VM Networking
 =============
@@ -190,21 +211,24 @@ This example creates a virtual machine manager (VMM) and configuration.
 
 .. code-block:: python
 
-   # Import the namespaces related classes from model
-   from cobra.model.vmm import ProvP, DomP, UsrAccP, CtrlrP, RsAcc
-   from cobra.model.infra import RsVlanNs
-
-   vmmProvP = ProvP('uni', 'VMWare')
-   vmmDomP = DomP(vmmProvP, 'Datacenter')
-   vmmUsrAccP = UsrAccP(vmmDomP, 'default', pwd='password', usr='administrator')
-   vmmRsVlanNs = RsVlanNs(vmmDomP, fvnsVlanInstP.dn)
-   vmmCtrlrP = CtrlrP(vmmDomP, 'vserver-01', hostOrIp='192.168.64.9')
-   vmmRsAcc = RsAcc(vmmCtrlrP, tDn=vmmUsrAccp.dn)
-
-   # Add the tenant object to the config request and commit
-   confgReq.addMo(fvTenantMo)
-   moDir.commit(configReq)
-
+    >>> # Import the namespaces related classes from model
+    ... 
+    >>> from cobra.model.vmm import ProvP, DomP, UsrAccP, CtrlrP, RsAcc
+    >>> from cobra.model.infra import RsVlanNs
+    >>> 
+    >>> vmmProvP = ProvP('uni', 'VMware')
+    >>> vmmDomP = DomP(vmmProvP, 'Datacenter')
+    >>> vmmUsrAccP = UsrAccP(vmmDomP, 'default', pwd='password', usr='user') 
+    >>> vmmRsVlanNs = RsVlanNs(vmmDomP, fvnsVlanInstP.dn)  
+    >>> vmmCtrlrP = CtrlrP(vmmDomP, 'vserver-01', hostOrIp='192.168.64.9')
+    >>> vmmRsAcc = RsAcc(vmmCtrlrP, tDn=vmmUsrAccP.dn)
+    >>> 
+    >>> # Add the tenant object to the config request and commit
+    ... 
+    >>> configReq.addMo(fvTenantMo) 
+    >>> moDir.commit(configReq)
+    <Response [200]>
+    >>> 
 
 Creating a Complete Tenant Configuration
 ========================================
@@ -226,11 +250,15 @@ whose nodeId property is 101.
 
 .. code-block:: python
 
-   # Import the related classes from model
-   from cobra.model.fabric import PathEpCont
-
-   nodeId = 101
-   myClassQuery.propFilter = 'eq(fabricPathEpCont.nodeId, "{0}")'.format(nodeId)
+    >>> from cobra.mit.request import ClassQuery
+    >>> 
+    >>> from cobra.model.fabric import PathEpCont 
+    >>> 
+    >>> nodeId = 101
+    >>> myClassQuery = ClassQuery('fabricPathEpCont')
+    >>> myClassQuery.propFilter = 'eq(fabricPathEpCont.nodeId,
+                                    "{0}")'.format(nodeId)
+    >>> 
 
 The basic filter syntax is 'condition(item1, "value")'.  To filter on the
 property of a class, the first item of the filter is of the form
@@ -246,22 +274,18 @@ a child object of a tenant MO.
 
 .. code-block:: python
 
-   dnQuery = DnQuery('uni/tn-coke')
-   dnQuery.subtree = 'children'
-   tenantMo = moDir.query(dnQuery)
-   defaultBDMo = tenantMo.BD['default']
-
-
-Iteration for a Child MO
-========================
-
-This example shows how to user iteration for a child MO.
-
-.. code-block:: python
-
-   dnQuery = DnQuery('uni/tn-coke')
-   dnQuery.subtree = 'children'
-   tenantMo = moDir.query(dnQuery)
-   for bdMo in tenantMo.BD:
-       print str(bdMo.dn)
-
+    >>> from cobra.mit.request import DnQuery
+    >>> 
+    >>> dnQuery = DnQuery('uni/tn-common')
+    >>> dnQuery.queryTarget = 'children' 
+    >>> dnQuery.classFilter = 'fvBD' 
+    >>>         
+    >>> tenantMo = moDir.query(dnQuery)
+    >>> 
+    >>> for t in tenantMo:
+    ...     print(t.dn)
+    ... 
+    uni/tn-common/BD-default
+    uni/tn-common/BD-common-BD1-test
+    uni/tn-common/BD-bd-commonShared
+    >>>

--- a/docs/source/api-ref/mo.rst
+++ b/docs/source/api-ref/mo.rst
@@ -13,11 +13,13 @@ profiles, and policies are logical entities represented as MOs.
 
 Accessing Properties
 ---------------------
-When you create a managed object (MO), you can access properties as follows::
+When you create a managed object (MO), you can access properties as follows:
 
-    userMo = User('uni/userext', 'george')
-    userMo.firstName = 'George'
-    userMo.lastName = 'Washington'
+.. code-block:: python
+
+    >>> userMo = User('uni/userext', 'george')
+    >>> userMo.firstName = 'George'
+    >>> userMo.lastName = 'Washington'
 
 Managing Properties
 ---------------------

--- a/docs/source/api-ref/request.rst
+++ b/docs/source/api-ref/request.rst
@@ -110,11 +110,14 @@ ConfigRequest
 -------------
 
 Class that handles configuration requests. The
-:func:`cobra.mit.access.MoDirectory.commit` function uses this class.::
+:func:`cobra.mit.access.MoDirectory.commit` function uses this class.
 
-    # Import the config request
-    from cobra.mit.request import ConfigRequest
-    configReq = ConfigRequest()
+.. code-block:: python
+
+    >>> # Import the config request
+    ...
+    >>> from cobra.mit.request import ConfigRequest
+    >>> configReq = ConfigRequest()
 
 .. autoclass:: cobra.mit.request.ConfigRequest
    :members:
@@ -145,32 +148,42 @@ cobra.mit.request.TagRequest instance provided as the query object.
 
 Example Usage:
 
+.. code-block:: python
+
     >>> from cobra.mit.session import LoginSession
     >>> from cobra.mit.access import MoDirectory
     >>> from cobra.mit.request import TagsRequest
-    >>> session = LoginSession('https://192.168.10.10', 'george', 'pa$sW0rd!', secure=False)
-    >>> modir = MoDirectory(session)
-    >>> modir.login()
+    >>> 
+    >>> session = LoginSession('https://10.10.10.100', 'user', 'password')
+    >>> moDir = MoDirectory(session)
+    >>> moDir.login()
+    >>> 
     >>> tags = TagsRequest('uni/tn-common/ap-default')
-    >>> q = modir.query(tags)
-    >>> print q[0].name
+    >>> q = moDir.query(tags)
+    >>> print(q[0].name)
     pregnantSnake
-    >>> tags.remove = "pregnantSnake"
-    >>> modir.commit(tags)
+    >>> 
+    >>> tags.remove = 'pregnantSnake'
+    >>> moDir.commit(tags)
     <Response [200]>
+    >>> 
     >>> tags.add = ['That','is','1','dead','bird']
-    >>> modir.commit(tags)
+    >>> moDir.commit(tags)
     <Response [200]>
+    >>> 
     >>> tags.add = "" ; tags.remove = []
-    >>> q = modir.query(tags)
+    >>> q = moDir.query(tags)
+    >>> 
     >>> tags.remove = ','.join([rem.name for rem in q])
-    >>> print tags.remove
-    u'is,That,dead,bird,1'
-    >>> print tags.getUrl(session)
-    https://192.168.10.10/api/tag/mo/uni/tn-common/ap-default.json?remove=bird,1,is,That,dead
-    >>> modir.commit(tags)
+    >>> print(tags.remove)
+    That,dead,bird,1,is
+    >>> 
+    >>> print(tags.getUrl(session))
+    https://10.10.10.100/api/tag/mo/uni/tn-common/ap-default.xml?remove=That,dead,bird,1,is
+    >>>             
+    >>> moDir.commit(tags)
     <Response [200]>
-    >>> modir.query(tags)
+    >>> moDir.query(tags)
     []
     >>>
 

--- a/docs/source/api-ref/services.rst
+++ b/docs/source/api-ref/services.rst
@@ -6,15 +6,21 @@ This module provides an interface to uploading L4-7 device packages to the
 controller. Refer to the **Developing L4-L7 Device Packages** document for more
 information on creating device packages.
 
-Example::
+Example Usage:
 
-    session = cobra.mit.session.LoginSession('https://apic', 'admin',
-                                             'password', secure=False)
-    moDir = cobra.mit.access.MoDirectory(session)
-    moDir.login()
+.. code-block:: python
 
-    packageUpload = cobra.services.UploadPackage('asa-device-pkg.zip')
-    response = moDir.commit(packageUpload)
+    >>> from cobra.mit.session import LoginSession
+    >>> from cobra.mit.access import MoDirectory
+    >>> from cobra.services import UploadPackage
+    >>> 
+    >>> session = LoginSession('https://10.10.10.100', 'user', 'password')
+    >>> moDir = MoDirectory(session)
+    >>> moDir.login()
+    >>> 
+    >>> packageUpload = UploadPackage('asa-device-pkg.zip')
+    >>> response = moDir.commit(packageUpload)
+    >>> 
 
 The following sections describe the classes in the services module.
 

--- a/docs/source/api-ref/session.rst
+++ b/docs/source/api-ref/session.rst
@@ -95,6 +95,7 @@ can be used for that user.
     >>> # Generation of a certificate and private key using the subprocess module to
     ... # make direct calls to openssl at the shell level.  This assumes that
     ... # openssl is installed on the system.
+    ...
     >>>
     >>> from subprocess import Popen, CalledProcessError, PIPE
     >>> 

--- a/docs/source/api-ref/session.rst
+++ b/docs/source/api-ref/session.rst
@@ -54,7 +54,7 @@ Example of using a LoginSession:
    from cobra.mit.access import MoDirectory
    from cobra.mit.access import LoginSession
 
-   session = LoginSession('http://10.1.1.1', 'user', 'password', secure=False)
+   session = LoginSession('https://10.10.10.100', 'user', 'password')
    moDir = MoDirectory(session)
    allTenants = moDir.lookupByClass('fvTenant')
    print(allTenants)
@@ -92,64 +92,83 @@ can be used for that user.
 
 .. code-block:: python
 
-   # Generation of a certificate and private key using the subprocess module to
-   # make direct calls to openssl at the shell level.  This assumes that
-   # openssl is installed on the system.
-
-   from subprocess import Popen, CalledProcessError, PIPE
-   from cobra.mit.access import MoDirectory
-   from cobra.mit.session import LoginSession
-   from cobra.mit.request import ConfigRequest
-   from cobra.model.pol import Uni as PolUni
-   from cobra.model.aaa import UserEp as AaaUserEp
-   from cobra.model.aaa import User as AaaUser
-   from cobra.model.aaa import UserDomain as AaaUserDomain
-   from cobra.model.aaa import UserRole as AaaUserRole
-   from cobra.model.aaa import UserCert as AaaUserCert
-
-   certUser = 'myuser'
-   pKeyFile = 'myuser.key'
-   certFile = 'myuser.cert'
-
-   # Generate the certificate in the current directory
-   cmd = ["openssl", "req", "-new", "-newkey", "rsa:1024", "-days", "36500",
-          "-nodes", "-x509", "-keyout", pKeyFile, "-out", certFile,
-          "-subj", "/CN=Generic/O=Acme/C=US"]
-   proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-   out, error = proc.communicate()
-   # If an error occurs, fail
-   if proc.returncode != 0:
-       print("Output: {0}, Error {1}".format(out, error))
-       raise CalledProcessError(proc.returncode, " ".join(cmd))
-
-   # At this point pKeyFile and certFile exist as files in the local directory.
-   # pKeyFile will be used when we want to generate signatures.  certFile is
-   # contains the X.509 certificate (with public key) that needs to be pushed
-   # to the APIC for a local user.
-
-   with open(certFile, "r") as file:
-       PEMdata = file.read()
-
-   # Generate a local user to commit to the APIC
-   polUni = PolUni('')
-   aaaUserEp = AaaUserEp(polUni)
-   aaaUser = AaaUser(aaaUserEp, certUser)
-   aaaUserDomain = AaaUserDomain(aaaUser, name='all')
-   # Other aaaUserRoles maybe needed to give the user other privileges
-   aaaUserRole = AaaUserRole(aaaUserDomain, name='read-all',
-                             privType='readPriv')
-   # Attach the certificate to that user.
-   aaaUserCert = AaaUserCert(aaaUser, certUser + '-cert')
-   # Using the data read in from the certificate file.
-   aaaUserCert.data = PEMdata
-
-   # Push the new local user to the APIC
-   session = LoginSession('https://10.1.1.1', 'admin', 'ins3965!', secure=False)
-   moDir = MoDirectory(session)
-   moDir.login()
-   cr = ConfigRequest()
-   cr.addMo(aaaUser)
-   moDir.commit(cr)
+    >>> # Generation of a certificate and private key using the subprocess module to
+    ... # make direct calls to openssl at the shell level.  This assumes that
+    ... # openssl is installed on the system.
+    >>>
+    >>> from subprocess import Popen, CalledProcessError, PIPE
+    >>> 
+    >>> from cobra.mit.session import LoginSession
+    >>> from cobra.mit.access import MoDirectory
+    >>> from cobra.mit.request import ConfigRequest
+    >>> 
+    >>> from cobra.model.pol import Uni as PolUni
+    >>> from cobra.model.aaa import UserEp as AaaUserEp
+    >>> from cobra.model.aaa import User as AaaUser
+    >>> from cobra.model.aaa import UserDomain as AaaUserDomain
+    >>> from cobra.model.aaa import UserRole as AaaUserRole
+    >>> from cobra.model.aaa import UserCert as AaaUserCert
+    >>> 
+    >>> certUser = 'myuser'
+    >>> pKeyFile = 'myuser.key'
+    >>> certFile = 'myuser.cert'
+    >>>
+    >>> # Generate the certificate in the current directory
+    ...
+    >>> cmd = ['openssl', 'req', '-new', '-newkey', 'rsa:1024', '-days', '36500',
+    ...        '-nodes', '-x509', '-keyout', pKeyFile, '-out', certFile, 
+    ...        '-subj', '/CN=APIC/O=Cisco/C=US']      
+    >>> proc = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+    >>> out, error = proc.communicate()
+    >>>
+    >>> # If an error occurs, fail
+    ...
+    >>> if proc.returncode != 0:
+    ...     print('Output: {0}, Error {1}'.format(out, error))
+    ...     raise CalledProcessError(proc.returncode, ' '.join(cmd))
+    ...
+    >>>
+    >>> # At this point pKeyFile and certFile exist as files in the local directory.
+    ... # pKeyFile will be used when we want to generate signatures.  certFile is
+    ... # contains the X.509 certificate (with public key) that needs to be pushed
+    ... # to the APIC for a local user.
+    ...
+    >>>
+    >>> with open(certFile, 'r') as file:
+    ...     PEMdata = file.read()
+    ... 
+    >>>
+    >>> # Generate a local user to commit to the APIC
+    ...
+    >>> polUni = PolUni('')
+    >>> aaaUserEp = AaaUserEp(polUni)
+    >>> aaaUser = AaaUser(aaaUserEp, certUser)
+    >>> aaaUserDomain = AaaUserDomain(aaaUser, name='all')
+    >>>
+    >>> # Other aaaUserRoles maybe needed to give the user other privileges
+    ...
+    >>> aaaUserRole = AaaUserRole(aaaUserDomain, name='read-all',
+    ...                           privType='readPriv')
+    >>>
+    >>> # Attach the certificate to that user
+    ...
+    >>> aaaUserCert = AaaUserCert(aaaUser, certUser + '-cert')
+    >>>
+    >>> # Using the data read in from the certificate file
+    ...
+    >>> aaaUserCert.data = PEMdata
+    >>>
+    >>> # Push the new local user to the APIC
+    ...
+    >>> session = LoginSession('https://10.10.10.100', 'user', 'password')
+    >>> moDir = MoDirectory(session)
+    >>> moDir.login()
+    >>>   
+    >>> cr = ConfigRequest()
+    >>> cr.addMo(aaaUser)
+    >>> moDir.commit(cr)
+    <Response [200]>
+    >>>
 
 Steps 2 and 3: Instantiate and use a CertSession class
 """"""""""""""""""""""""""""""""""""""""""""""""""""""
@@ -172,36 +191,53 @@ a CertSession:
 
 .. code-block:: python
 
-   from cobra.mit.access import MoDirectory
-   from cobra.mit.session import CertSession
-   from cobra.model.pol import Uni as PolUni
-   from cobra.model.aaa import UserEp as AaaUserEp
-   from cobra.model.aaa import User as AaaUser
-   from cobra.model.aaa import UserCert as AaaUserCert
-
-   certUser = 'myuser'
-   pKeyFile = 'myuser.key'
-
-   # Generate a local user object that matches the one on the APIC
-   # This is only being used to get the Dn of the user's certificate
-   polUni = PolUni('')
-   aaaUserEp = AaaUserEp(polUni)
-   aaaUser = AaaUser(aaaUserEp, certUser)
-   # Attach the certificate to that user.
-   aaaUserCert = AaaUserCert(aaaUser, certUser + '-cert')
-
-   # Read in the private key data from a file in the local directory
-   with open(pKeyFile, "r") as file:
-       pKey = file.read()
-
-   # Instantiate a CertSession using the dn and private key
-   session = CertSession('https://10.1.1.1', aaaUserCert.dn, pKey, secure=False)
-   moDir = MoDirectory(session)
-
-   # No login is required for certificate based sessions
-   allTenants = moDir.lookupByClass('fvTenant')
-   print(allTenants)
-
+    >>> from cobra.mit.session import CertSession
+    >>> from cobra.mit.access import MoDirectory
+    >>> 
+    >>> from cobra.model.pol import Uni as PolUni
+    >>> from cobra.model.aaa import UserEp as AaaUserEp
+    >>> from cobra.model.aaa import User as AaaUser
+    >>> from cobra.model.aaa import UserCert as AaaUserCert
+    >>> 
+    >>> certUser = 'myuser'
+    >>> pKeyFile = 'myuser.key'
+    >>> 
+    >>> # Generate a local user object that mactches the one on the APIC
+    ... # This is only being used to get the Dn of the user's certificate
+    ... 
+    >>> polUni = PolUni('')
+    >>> aaaUserEp = AaaUserEp(polUni)
+    >>> aaaUser = AaaUser(aaaUserEp, certUser)
+    >>> 
+    >>> # Attach the certificate to that user
+    ... 
+    >>> aaaUserCert = AaaUserCert(aaaUser, certUser + '-cert')
+    >>> 
+    >>> # Read in the private key data from a file in the local directory 
+    ... 
+    >>> with open(pKeyFile, 'r') as file:
+    ...     pKey = file.read()
+    ... 
+    >>> 
+    >>> # Instantiate a CertSession using the Dn and private key
+    ... 
+    >>> session = CertSession('https://10.10.10.100', aaaUserCert.dn, pKey)
+    >>> moDir = MoDirectory(session)
+    >>> 
+    >>> # No login is required for certificate based sessions
+    ... 
+    >>> allTenants = moDir.lookupByClass('fvTenant')
+    >>> for tenant in allTenants:
+    ...     print(tenant.name)
+    ... 
+    Red
+    Blue
+    Zach
+    Purple
+    Mike
+    Green
+    Sand
+    >>> 
 
 .. autoclass:: cobra.mit.session.CertSession
    :members:


### PR DESCRIPTION
Convert code examples in the docs to python terminal output so we can use doctest from py.test to verify the examples.

Addresses #63
