### PR TITLE
Cobra SDK Vs APIC Version incompatibility

### DIFF
--- a/cobra/internal/base/moimpl.py
+++ b/cobra/internal/base/moimpl.py
@@ -435,6 +435,11 @@ class BaseMo(object):
         props = self.__meta.props
         for name, value in list(creationProps.items()):
             propMeta = props[name]
+            # Ideally, we should be raising an Exception to let the upper layers
+            # handle it. But there's a user-case where the props that are provided
+            # are part of an upgraded meta and hence need to be ignored.
+            if not propMeta:
+                continue
             value = propMeta.makeValue(value)
             self.__dict__[name] = value
             if markDirty:

--- a/cobra/mit/meta.py
+++ b/cobra/mit/meta.py
@@ -361,7 +361,7 @@ class ClassMeta(object):
             return list(self._props.keys())
 
         def __getitem__(self, propName):
-            return self._props[propName]
+            return self._props.get(propName, None)
 
         def __contains__(self, propName):
             return propName in self._props


### PR DESCRIPTION
Cobra SDK is being run at a client that runs independently of the APIC's
version. In such cases, the REST payload can contain properies that are
not available as part of the client's cobra model.

This fix will ignore such non-existent properties.
