### PR TITLE
Remove leading spaces from the header while sending a cobra request

### DIFF
--- a/cobra/mit/session.py
+++ b/cobra/mit/session.py
@@ -817,7 +817,7 @@ class CertSession(AbstractSession):
                 except:   # pylint:disable=bare-except
                     pass  # pylint:disable=pointless-except
 
-        cookieFmt = ("  APIC-Request-Signature=%s;" +
+        cookieFmt = ("APIC-Request-Signature=%s;" +
                      " APIC-Certificate-Algorithm=v1.0;" +
                      " APIC-Certificate-Fingerprint=fingerprint;" +
                      " APIC-Certificate-DN=%s")


### PR DESCRIPTION
If the user is trying to authenticate using CertSession, python requests library version > 2.9.1 will throw an exception due to changes in the requests library header requirements. This commit will make cobra compatible with the latest versions of requests.py